### PR TITLE
Fix: 'has_email' 제거

### DIFF
--- a/src/passports/kakao-strategy.ts
+++ b/src/passports/kakao-strategy.ts
@@ -13,9 +13,11 @@ export default () => {
       { ...KAKAO_CONFIG },
       async (accessToken, _refreshToken, profile, cb) => {
         // eslint-disable-next-line no-underscore-dangle
-        const { has_email, email } = profile._json.kakao_account
-        if (!has_email || !email) {
-          return cb(new NotFoundError('Not Found Email'))
+        const { email } = profile._json.kakao_account
+        if (!email) {
+          return cb(
+            new NotFoundError('You must agree to use your Kakao account email')
+          )
         }
         const user = await userService.findUserByEmail({ email })
 


### PR DESCRIPTION
## 작업내용
* `kakao-strategy`에서 `has_email` 제거

## 주의사항
 * 다음카카오 이메일함에 연동된 이메일을 말하는 듯 합니다.