### PR TITLE
[#70] 공유딜 엔티티에 이미지 필드추가

### DIFF
--- a/apps/app/src/module/share-deal/adapter/in/gql/input/OpenShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/OpenShareDealInput.ts
@@ -25,6 +25,9 @@ export class OpenShareDealInput {
   @Field()
   storeName: string;
 
+  @Field()
+  thumbnail: string;
+
   @Field(() => CreateShareZoneInput)
   @Type(() => CreateShareZoneInput)
   @ValidateNested()
@@ -38,6 +41,7 @@ export class OpenShareDealInput {
       this.minParticipants,
       this.orderPrice,
       this.storeName,
+      this.thumbnail,
       this.shareZone.addressRoad,
       this.shareZone.addressDetail,
       this.shareZone.latitude,

--- a/apps/app/src/module/share-deal/adapter/in/gql/response/ShareDealResponse.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/response/ShareDealResponse.ts
@@ -26,6 +26,9 @@ export class ShareDealResponse {
   @Field()
   currentParticipants: number;
 
+  @Field()
+  thumbnail: string;
+
   @Field(() => ShareDealStatus)
   status: ShareDealStatus;
 
@@ -40,6 +43,7 @@ export class ShareDealResponse {
     response.minParticipants = shareDeal.minParticipants;
     response.currentParticipants = shareDeal.participantCount;
     response.status = shareDeal.status;
+    response.thumbnail = shareDeal.thumbnail;
 
     return response;
   }

--- a/apps/app/src/module/share-deal/adapter/out/persistence/ShareDealOrmMapper.ts
+++ b/apps/app/src/module/share-deal/adapter/out/persistence/ShareDealOrmMapper.ts
@@ -14,6 +14,7 @@ export class ShareDealOrmMapper {
       ownerId: orm.ownerId,
       participantIds: orm.participantIds,
       storeName: orm.storeName,
+      thumbnail: orm.thumbnail,
       title: orm.title,
       status: ShareDealStatus[orm.status as ShareDealStatus],
       zone: new ShareZone(
@@ -36,6 +37,7 @@ export class ShareDealOrmMapper {
       ownerId: domain.ownerId,
       participantIds: domain.participantIds,
       storeName: domain.storeName,
+      thumbnail: domain.thumbnail,
       title: domain.title,
       zone: {
         road: domain.zone.road,

--- a/apps/app/src/module/share-deal/application/port/in/dto/OpenShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/OpenShareDealCommand.ts
@@ -10,6 +10,7 @@ export class OpenShareDealCommand {
     readonly minParticipants: number,
     readonly orderPrice: number,
     readonly storeName: string,
+    readonly thumbnail: string,
     readonly addressRoad: string,
     readonly addressDetail: string,
     readonly latitude: number,
@@ -24,6 +25,7 @@ export class OpenShareDealCommand {
       orderPrice: this.orderPrice,
       ownerId: this.userId,
       storeName: this.storeName,
+      thumbnail: this.thumbnail,
       zone: new ShareZone(
         this.addressRoad,
         this.addressDetail,

--- a/apps/app/src/module/share-deal/domain/ShareDeal.ts
+++ b/apps/app/src/module/share-deal/domain/ShareDeal.ts
@@ -13,6 +13,7 @@ export interface ShareDealProps {
   ownerId: string;
   participantIds: string[];
   storeName: string;
+  thumbnail: string;
   zone: ShareZone;
 }
 
@@ -64,6 +65,10 @@ export class ShareDeal extends BaseEntity<ShareDealProps> {
 
   get participantCount(): number {
     return this.participantIds.length + 1;
+  }
+
+  get thumbnail(): string {
+    return this.props.thumbnail;
   }
 
   static open(props: CreateShareDealProps) {

--- a/apps/app/test/fixture/ShareDealFactory.ts
+++ b/apps/app/test/fixture/ShareDealFactory.ts
@@ -32,6 +32,7 @@ export class ShareDealFactory {
       orderPrice: faker.datatype.number(),
       ownerId: faker.database.mongodbObjectId(),
       storeName: faker.word.noun(),
+      thumbnail: faker.image.imageUrl(),
       zone: shareZone,
       ...props,
     }).setBase(

--- a/apps/app/test/share-deal/integration/ShareDealRepositoryAdapter.spec.ts
+++ b/apps/app/test/share-deal/integration/ShareDealRepositoryAdapter.spec.ts
@@ -36,6 +36,7 @@ describe('ShareDealRepositoryAdapter', () => {
         orderPrice: 2000,
         ownerId: faker.database.mongodbObjectId(),
         storeName: 'store',
+        thumbnail: 'thumbnail',
         zone: shareZone,
       });
 

--- a/apps/app/test/share-deal/unit/ShareDealCommandService.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDealCommandService.spec.ts
@@ -27,6 +27,7 @@ describe('ShareDealCommandService', () => {
         10,
         1000,
         'store',
+        'thumbnail',
         'road',
         'detail',
         123,

--- a/apps/app/test/share-deal/unit/ShareDealMutationResolver.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDealMutationResolver.spec.ts
@@ -43,6 +43,7 @@ describe('ShareDealMutationResolver', () => {
       input.minParticipants = 2;
       input.storeName = 'IPPPPPPPPPAAZ';
       input.orderPrice = 1000;
+      input.thumbnail = 'thumbnail';
 
       const shareZoneInput = new CreateShareZoneInput();
       shareZoneInput.addressDetail = 'detail';

--- a/apps/app/test/share-deal/unit/ShareDealQueryResolver.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDealQueryResolver.spec.ts
@@ -54,6 +54,7 @@ describe('ShareDealQueryResolver', () => {
           minParticipants
           currentParticipants
           status
+          thumbnail
         }
       }`;
 
@@ -64,6 +65,7 @@ describe('ShareDealQueryResolver', () => {
         title: 'title',
         participantIds: ['1', '2', '3'],
         createdAt: new Date('2022-01-01'),
+        thumbnail: 'thumbnail',
       });
 
       shareDealQueryRepositoryPort.find.mockReturnValue(right([shareDeal]));
@@ -86,6 +88,7 @@ describe('ShareDealQueryResolver', () => {
                 "minParticipants": 10,
                 "orderPrice": 1000,
                 "status": "OPEN",
+                "thumbnail": "thumbnail",
                 "title": "title",
               },
             ],

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -92,6 +92,7 @@ model ShareDeal {
   ownerId         String    @db.ObjectId
   participantIds  String[]  @db.ObjectId
   storeName       String
+  thumbnail       String
   zone            ShareZone
 }
 

--- a/schema/schema.gql
+++ b/schema/schema.gql
@@ -133,6 +133,7 @@ input OpenShareDealInput {
   orderPrice: Float!
   shareZone: CreateShareZoneInput!
   storeName: String!
+  thumbnail: String!
   title: String!
 }
 
@@ -175,6 +176,7 @@ type ShareDealResponse {
   minParticipants: Float!
   orderPrice: Float!
   status: ShareDealStatus!
+  thumbnail: String!
   title: String!
 }
 


### PR DESCRIPTION
<img width="306" alt="CleanShot 2022-09-19 at 09 56 25@2x" src="https://user-images.githubusercontent.com/22140938/190935624-ee26ac62-7b82-4dae-9888-aa49600d9dcb.png">

공유딜 생성할 때 이미지는 프론트에서 음식 카테고리별로 선정된 항목중에 랜덤으로 선택하는 방식으로 확인
공유딜 목록에서 이미지를 보여줘야 하므로 백엔드에서 어떤 이미지인지 저장해야함