### PR TITLE
[#102] 전화번호 인증번호 검증 api 에러처리 로직 수정

### DIFF
--- a/apps/app/src/module/user/application/port/in/PhoneVerificationUseCase.ts
+++ b/apps/app/src/module/user/application/port/in/PhoneVerificationUseCase.ts
@@ -1,16 +1,18 @@
 import { DBError } from '@app/domain/error/DBError';
 import { NotificationError } from '@app/domain/error/NotificationError';
-import { IllegalStateException } from '@app/domain/exception/IllegalStateException';
 import { NotFoundException } from '@app/domain/exception/NotFoundException';
 import { TaskEither } from 'fp-ts/TaskEither';
 
+import { ExpiredCodeException } from '../../../domain/exception/ExpiredCodeException';
+import { MismatchedCodeException } from '../../../domain/exception/MismatchedCodeException';
 import { SendPhoneVerificationCodeCommand } from './dto/SendPhoneVerificationCodeCommand';
 import { VerifyPhoneVerificationCodeCommand } from './dto/VerifyPhoneVerificationCodeCommand';
 
 export type VerifyPhoneVerificationCodeError =
   | DBError
   | NotFoundException
-  | IllegalStateException;
+  | ExpiredCodeException
+  | MismatchedCodeException;
 
 export abstract class PhoneVerificationUseCase {
   abstract sendCode(

--- a/apps/app/src/module/user/domain/PhoneVerification.ts
+++ b/apps/app/src/module/user/domain/PhoneVerification.ts
@@ -1,8 +1,10 @@
 import { randomInt } from 'crypto';
 
-import { IllegalStateException } from '@app/domain/exception/IllegalStateException';
 import { addMinutes, isAfter } from 'date-fns';
 import { Either, left, right } from 'fp-ts/Either';
+
+import { ExpiredCodeException } from './exception/ExpiredCodeException';
+import { MismatchedCodeException } from './exception/MismatchedCodeException';
 
 export class PhoneVerification {
   static readonly EXPIRATION_MINUTES = 3;
@@ -21,10 +23,13 @@ export class PhoneVerification {
     );
   }
 
-  verify(code: string, now = new Date()): Either<IllegalStateException, void> {
+  verify(
+    code: string,
+    now = new Date(),
+  ): Either<ExpiredCodeException | MismatchedCodeException, void> {
     if (this.code !== code) {
       return left(
-        new IllegalStateException(
+        new MismatchedCodeException(
           `코드가 일치하지 않습니다: expected=${this.code}, actual=${code}`,
         ),
       );
@@ -32,7 +37,7 @@ export class PhoneVerification {
 
     if (this.isExpired(now)) {
       return left(
-        new IllegalStateException(
+        new ExpiredCodeException(
           `코드가 만료되었습니다: expiredAt=${this.expiredAt}`,
         ),
       );

--- a/apps/app/src/module/user/domain/User.ts
+++ b/apps/app/src/module/user/domain/User.ts
@@ -4,6 +4,8 @@ import * as E from 'fp-ts/Either';
 import { Either } from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 
+import { ExpiredCodeException } from './exception/ExpiredCodeException';
+import { MismatchedCodeException } from './exception/MismatchedCodeException';
 import { PhoneVerification } from './PhoneVerification';
 import { Address } from './vo/Address';
 import { Agreement } from './vo/Agreement';
@@ -78,7 +80,7 @@ export class User extends BaseEntity<UserProps> {
   updateByPhoneVerification(
     phoneVerification: PhoneVerification,
     code: string,
-  ): Either<IllegalStateException, this> {
+  ): Either<ExpiredCodeException | MismatchedCodeException, this> {
     return pipe(
       phoneVerification.verify(code),
       E.map(() => {

--- a/apps/app/src/module/user/domain/exception/ExpiredCodeException.ts
+++ b/apps/app/src/module/user/domain/exception/ExpiredCodeException.ts
@@ -1,0 +1,9 @@
+import { BaseException } from '@app/domain/exception/BaseException';
+
+export class ExpiredCodeException extends BaseException {
+  override readonly code = 'EXPIRED_CODE';
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/apps/app/src/module/user/domain/exception/MismatchedCodeException.ts
+++ b/apps/app/src/module/user/domain/exception/MismatchedCodeException.ts
@@ -1,0 +1,9 @@
+import { BaseException } from '@app/domain/exception/BaseException';
+
+export class MismatchedCodeException extends BaseException {
+  override readonly code = 'MISMATCHED_CODE';
+
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/apps/app/test/user/unit/PhoneVerification.spec.ts
+++ b/apps/app/test/user/unit/PhoneVerification.spec.ts
@@ -1,5 +1,7 @@
 import { addSeconds } from 'date-fns';
 
+import { ExpiredCodeException } from '../../../src/module/user/domain/exception/ExpiredCodeException';
+import { MismatchedCodeException } from '../../../src/module/user/domain/exception/MismatchedCodeException';
 import { PhoneVerification } from '../../../src/module/user/domain/PhoneVerification';
 import { assertLeft, assertRight } from '../../fixture';
 
@@ -25,6 +27,7 @@ describe('PhoneVerification', () => {
 
       // then
       assertLeft(result, (err) => {
+        expect(err).toBeInstanceOf(MismatchedCodeException);
         expect(err.message).toContain('코드가 일치하지 않습니다');
       });
     });
@@ -41,6 +44,7 @@ describe('PhoneVerification', () => {
 
       // then
       assertLeft(result, (err) => {
+        expect(err).toBeInstanceOf(ExpiredCodeException);
         expect(err.message).toContain('코드가 만료되었습니다');
       });
     });

--- a/apps/app/test/user/unit/PhoneVerificationService.spec.ts
+++ b/apps/app/test/user/unit/PhoneVerificationService.spec.ts
@@ -1,4 +1,3 @@
-import { IllegalStateException } from '@app/domain/exception/IllegalStateException';
 import { NotFoundException } from '@app/domain/exception/NotFoundException';
 import { SmsPort } from '@app/domain/notification/SmsPort';
 import { left, right } from 'fp-ts/TaskEither';
@@ -10,6 +9,7 @@ import { PhoneVerificationRepositoryPort } from '../../../src/module/user/applic
 import { UserQueryRepositoryPort } from '../../../src/module/user/application/port/out/UserQueryRepositoryPort';
 import { UserRepositoryPort } from '../../../src/module/user/application/port/out/UserRepositoryPort';
 import { PhoneVerificationService } from '../../../src/module/user/application/service/PhoneVerificationService';
+import { MismatchedCodeException } from '../../../src/module/user/domain/exception/MismatchedCodeException';
 import { PhoneVerification } from '../../../src/module/user/domain/PhoneVerification';
 import { User } from '../../../src/module/user/domain/User';
 import { Auth } from '../../../src/module/user/domain/vo/Auth';
@@ -86,7 +86,7 @@ describe('PhoneVerificationService', () => {
 
       // then
       await assertResolvesLeft(result, (err) => {
-        expect(err).toBeInstanceOf(IllegalStateException);
+        expect(err).toBeInstanceOf(MismatchedCodeException);
       });
     });
 


### PR DESCRIPTION
fe에서 인증번호 검증 시 발생하는 에러 2가지 경우에 대한 분기를 위해 작업한 내용입니다

- 인증번호가 일치하지 않음
- 인증 유효시간이 지나감
