### PR TITLE
[#153] userId branded type으로 교체

### DIFF
--- a/apps/app/src/module/chat/adapter/in/gql/input/FindChatDetailInput.ts
+++ b/apps/app/src/module/chat/adapter/in/gql/input/FindChatDetailInput.ts
@@ -1,6 +1,7 @@
 import { Field, ID, InputType, Int } from '@nestjs/graphql';
 import { IsPositive } from 'class-validator';
 
+import { UserId } from '../../../../../user/domain/User';
 import { FindChatByUserCommand } from '../../../../application/port/in/dto/FindChatByUserCommand';
 
 @InputType()
@@ -15,7 +16,7 @@ export class FindChatDetailInput {
   @IsPositive()
   size: number;
 
-  toCommand(userId: string): FindChatByUserCommand {
+  toCommand(userId: UserId): FindChatByUserCommand {
     return new FindChatByUserCommand(
       this.shareDealId,
       userId,

--- a/apps/app/src/module/chat/adapter/in/gql/input/FindChatInput.ts
+++ b/apps/app/src/module/chat/adapter/in/gql/input/FindChatInput.ts
@@ -2,6 +2,7 @@ import { Field, InputType, Int } from '@nestjs/graphql';
 import { IsPositive, Min } from 'class-validator';
 
 import { ShareDealStatus } from '../../../../../share-deal/domain/vo/ShareDealStatus';
+import { UserId } from '../../../../../user/domain/User';
 import { FindChatCommand } from '../../../../application/port/in/dto/FindChatCommand';
 
 @InputType()
@@ -17,7 +18,7 @@ export class FindChatInput {
   @IsPositive()
   size: number;
 
-  toCommand(userId: string): FindChatCommand {
+  toCommand(userId: UserId): FindChatCommand {
     return new FindChatCommand(userId, this.status, this.page, this.size);
   }
 }

--- a/apps/app/src/module/chat/adapter/in/gql/input/WriteChatInput.ts
+++ b/apps/app/src/module/chat/adapter/in/gql/input/WriteChatInput.ts
@@ -1,5 +1,6 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { WriteChatCommand } from '../../../../application/port/in/dto/WriteChatCommand';
 
 @InputType()
@@ -10,7 +11,7 @@ export class WriteChatInput {
   @Field()
   content: string;
 
-  toCommand(userId: string): WriteChatCommand {
+  toCommand(userId: UserId): WriteChatCommand {
     return new WriteChatCommand(userId, this.shareDealId, this.content);
   }
 }

--- a/apps/app/src/module/chat/adapter/in/gql/response/ChatDetailResponse.ts
+++ b/apps/app/src/module/chat/adapter/in/gql/response/ChatDetailResponse.ts
@@ -1,5 +1,6 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { FindByUserDto } from '../../../../application/port/in/dto/FindByUserDto';
 import { MessageType } from '../../../../domain/vo/MessageType';
 
@@ -20,7 +21,7 @@ export class ChatDetailResponse {
   @Field({ description: '내가 쓴 글인지 여부' })
   writtenByMe: boolean;
 
-  static of(dto: FindByUserDto, userId: string): ChatDetailResponse {
+  static of(dto: FindByUserDto, userId: UserId): ChatDetailResponse {
     const response = new ChatDetailResponse();
 
     response.id = dto.chat.id;

--- a/apps/app/src/module/chat/adapter/in/gql/response/ChatWrittenResponse.ts
+++ b/apps/app/src/module/chat/adapter/in/gql/response/ChatWrittenResponse.ts
@@ -1,12 +1,13 @@
 import { Field, ID, ObjectType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { Message } from '../../../../domain/vo/Message';
 import { MessageType } from '../../../../domain/vo/MessageType';
 
 @ObjectType()
 export class ChatWrittenResponse {
   @Field(() => ID)
-  authorId: string;
+  authorId: UserId;
 
   @Field(() => MessageType)
   type: MessageType;

--- a/apps/app/src/module/chat/adapter/out/persistence/ChatOrmMapper.ts
+++ b/apps/app/src/module/chat/adapter/out/persistence/ChatOrmMapper.ts
@@ -1,5 +1,6 @@
 import { Chat as OrmChat } from '@prisma/client';
 
+import { UserId } from '../../../../user/domain/User';
 import { Chat } from '../../../domain/Chat';
 import { Message } from '../../../domain/vo/Message';
 import { MessageType } from '../../../domain/vo/MessageType';
@@ -7,11 +8,11 @@ import { MessageType } from '../../../domain/vo/MessageType';
 export class ChatOrmMapper {
   static toDomain(orm: OrmChat): Chat {
     return new Chat({
-      userId: orm.userId,
+      userId: orm.userId as UserId,
       shareDealId: orm.shareDealId,
       orderedKey: orm.orderedKey,
       message: Message.of(
-        orm.message.authorId,
+        orm.message.authorId as UserId,
         orm.message.type as MessageType,
         orm.message.content,
         orm.message.unread,

--- a/apps/app/src/module/chat/adapter/out/persistence/ChatQueryRepositoryAdapter.ts
+++ b/apps/app/src/module/chat/adapter/out/persistence/ChatQueryRepositoryAdapter.ts
@@ -7,6 +7,7 @@ import { Option } from 'fp-ts/Option';
 import { TaskEither } from 'fp-ts/TaskEither';
 
 import { ChatOrmMapper } from './ChatOrmMapper';
+import { UserId } from '../../../../user/domain/User';
 import { FindChatByUserCommand } from '../../../application/port/in/dto/FindChatByUserCommand';
 import { ChatQueryRepositoryPort } from '../../../application/port/out/ChatQueryRepositoryPort';
 import { Chat } from '../../../domain/Chat';
@@ -19,7 +20,7 @@ export class ChatQueryRepositoryAdapter extends ChatQueryRepositoryPort {
 
   override last(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError, Option<Chat>> {
     return pipe(
       tryCatchDB(() =>
@@ -36,7 +37,7 @@ export class ChatQueryRepositoryAdapter extends ChatQueryRepositoryPort {
 
   override unreadCount(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError, number> {
     return pipe(
       tryCatchDB(async () =>

--- a/apps/app/src/module/chat/adapter/out/persistence/ChatRepositoryAdapter.ts
+++ b/apps/app/src/module/chat/adapter/out/persistence/ChatRepositoryAdapter.ts
@@ -6,6 +6,7 @@ import { constVoid, pipe } from 'fp-ts/function';
 import { TaskEither } from 'fp-ts/TaskEither';
 
 import { ChatOrmMapper } from './ChatOrmMapper';
+import { UserId } from '../../../../user/domain/User';
 import { ChatRepositoryPort } from '../../../application/port/out/ChatRepositoryPort';
 import { Chat } from '../../../domain/Chat';
 
@@ -30,7 +31,7 @@ export class ChatRepositoryAdapter extends ChatRepositoryPort {
 
   override updateRead(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError, void> {
     return pipe(
       tryCatchDB(async () =>

--- a/apps/app/src/module/chat/application/port/in/dto/FindChatByUserCommand.ts
+++ b/apps/app/src/module/chat/application/port/in/dto/FindChatByUserCommand.ts
@@ -1,9 +1,11 @@
 import { CursorCommand } from '@app/domain/command/CursorCommand';
 
+import { UserId } from '../../../../../user/domain/User';
+
 export class FindChatByUserCommand extends CursorCommand<string> {
   constructor(
     readonly shareDealId: string,
-    readonly userId: string,
+    readonly userId: UserId,
     cursor?: string,
     size?: number,
   ) {

--- a/apps/app/src/module/chat/application/port/in/dto/FindChatCommand.ts
+++ b/apps/app/src/module/chat/application/port/in/dto/FindChatCommand.ts
@@ -1,9 +1,10 @@
 import { FindByUserShareDealCommand } from '../../../../../share-deal/application/port/out/dto/FindByUserShareDealCommand';
 import { ShareDealStatus } from '../../../../../share-deal/domain/vo/ShareDealStatus';
+import { UserId } from '../../../../../user/domain/User';
 
 export class FindChatCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly shareDealStatus: ShareDealStatus,
     readonly page: number,
     readonly size: number,

--- a/apps/app/src/module/chat/application/port/in/dto/WriteChatCommand.ts
+++ b/apps/app/src/module/chat/application/port/in/dto/WriteChatCommand.ts
@@ -1,6 +1,8 @@
+import { UserId } from '../../../../../user/domain/User';
+
 export class WriteChatCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly shareDealId: string,
     readonly content: string,
   ) {}

--- a/apps/app/src/module/chat/application/port/out/ChatQueryRepositoryPort.ts
+++ b/apps/app/src/module/chat/application/port/out/ChatQueryRepositoryPort.ts
@@ -2,6 +2,7 @@ import { DBError } from '@app/domain/error/DBError';
 import { Option } from 'fp-ts/Option';
 import { TaskEither } from 'fp-ts/TaskEither';
 
+import { UserId } from '../../../../user/domain/User';
 import { Chat } from '../../../domain/Chat';
 import { FindChatByUserCommand } from '../in/dto/FindChatByUserCommand';
 
@@ -12,11 +13,11 @@ export abstract class ChatQueryRepositoryPort {
 
   abstract last(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError, Option<Chat>>;
 
   abstract unreadCount(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError, number>;
 }

--- a/apps/app/src/module/chat/application/port/out/ChatRepositoryPort.ts
+++ b/apps/app/src/module/chat/application/port/out/ChatRepositoryPort.ts
@@ -1,6 +1,7 @@
 import { DBError } from '@app/domain/error/DBError';
 import { TaskEither } from 'fp-ts/TaskEither';
 
+import { UserId } from '../../../../user/domain/User';
 import { Chat } from '../../../domain/Chat';
 
 export abstract class ChatRepositoryPort {
@@ -8,6 +9,6 @@ export abstract class ChatRepositoryPort {
 
   abstract updateRead(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError, void>;
 }

--- a/apps/app/src/module/chat/domain/Chat.ts
+++ b/apps/app/src/module/chat/domain/Chat.ts
@@ -1,9 +1,10 @@
 import { BaseEntity } from '@app/domain/entity/BaseEntity';
 
 import { Message } from './vo/Message';
+import { UserId } from '../../user/domain/User';
 
 export interface ChatProps {
-  userId: string;
+  userId: UserId;
   shareDealId: string;
   message: Message;
   orderedKey: string;
@@ -44,8 +45,8 @@ export class Chat extends BaseEntity<ChatProps> {
 
   static create(
     shareDealId: string,
-    participantIds: string[],
-    authorId: string,
+    participantIds: UserId[],
+    authorId: UserId,
     content: string,
     orderedKey: string,
   ): Chat[] {
@@ -61,8 +62,8 @@ export class Chat extends BaseEntity<ChatProps> {
 
   static createByStartShareDeal(
     shareDealId: string,
-    participantIds: string[],
-    authorId: string,
+    participantIds: UserId[],
+    authorId: UserId,
     orderedKey: string,
   ): Chat[] {
     return participantIds.map((id) =>
@@ -77,8 +78,8 @@ export class Chat extends BaseEntity<ChatProps> {
 
   static createByEndShareDeal(
     shareDealId: string,
-    participantIds: string[],
-    authorId: string,
+    participantIds: UserId[],
+    authorId: UserId,
     orderedKey: string,
   ): Chat[] {
     return participantIds.map((id) =>
@@ -93,8 +94,8 @@ export class Chat extends BaseEntity<ChatProps> {
 
   static createByCloseShareDeal(
     shareDealId: string,
-    participantIds: string[],
-    authorId: string,
+    participantIds: UserId[],
+    authorId: UserId,
     orderedKey: string,
   ): Chat[] {
     return participantIds.map((id) =>

--- a/apps/app/src/module/chat/domain/event/ChatReadEvent.ts
+++ b/apps/app/src/module/chat/domain/event/ChatReadEvent.ts
@@ -1,7 +1,9 @@
 import { DomainEvent } from '@app/domain/event/DomainEvent';
 
+import { UserId } from '../../../user/domain/User';
+
 export class ChatReadEvent extends DomainEvent {
-  constructor(readonly userId: string, readonly shareDealId: string) {
+  constructor(readonly userId: UserId, readonly shareDealId: string) {
     super();
   }
 }

--- a/apps/app/src/module/chat/domain/vo/Message.ts
+++ b/apps/app/src/module/chat/domain/vo/Message.ts
@@ -1,4 +1,5 @@
 import { MessageType } from './MessageType';
+import { UserId } from '../../../user/domain/User';
 
 export class Message {
   static FIRST_MESSAGE =
@@ -18,14 +19,14 @@ export class Message {
     '공유딜이 파기되었습니다.\n더이상의 채팅은 불가합니다.';
 
   private constructor(
-    readonly authorId: string,
+    readonly authorId: UserId,
     readonly type: MessageType,
     readonly content: string,
     readonly unread: boolean,
   ) {}
 
   static of(
-    authorId: string,
+    authorId: UserId,
     type: MessageType,
     content: string,
     unread: boolean,
@@ -33,11 +34,11 @@ export class Message {
     return new Message(authorId, type, content, unread);
   }
 
-  static normal(authorId: string, content: string, unread: boolean): Message {
+  static normal(authorId: UserId, content: string, unread: boolean): Message {
     return Message.of(authorId, MessageType.NORMAL, content, unread);
   }
 
-  static firstMessage(authorId: string): Message {
+  static firstMessage(authorId: UserId): Message {
     return new Message(
       authorId,
       MessageType.NOTICE,
@@ -46,7 +47,7 @@ export class Message {
     );
   }
 
-  static startShareDealMessage(authorId: string): Message {
+  static startShareDealMessage(authorId: UserId): Message {
     return new Message(
       authorId,
       MessageType.NOTICE,
@@ -55,7 +56,7 @@ export class Message {
     );
   }
 
-  static endShareDealMessage(authorId: string): Message {
+  static endShareDealMessage(authorId: UserId): Message {
     return new Message(
       authorId,
       MessageType.NOTICE,
@@ -64,7 +65,7 @@ export class Message {
     );
   }
 
-  static closeShareDealMessage(authorId: string): Message {
+  static closeShareDealMessage(authorId: UserId): Message {
     return new Message(
       authorId,
       MessageType.NOTICE,

--- a/apps/app/src/module/share-deal/adapter/in/gql/input/EndShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/EndShareDealInput.ts
@@ -1,5 +1,6 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { EndShareDealCommand } from '../../../../application/port/in/dto/EndShareDealCommand';
 
 @InputType()
@@ -7,7 +8,7 @@ export class EndShareDealInput {
   @Field(() => ID)
   shareDealId: string;
 
-  toCommand(userId: string) {
+  toCommand(userId: UserId) {
     return new EndShareDealCommand(userId, this.shareDealId);
   }
 }

--- a/apps/app/src/module/share-deal/adapter/in/gql/input/JoinShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/JoinShareDealInput.ts
@@ -1,5 +1,6 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { JoinShareDealCommand } from '../../../../application/port/in/dto/JoinShareDealCommand';
 
 @InputType()
@@ -7,7 +8,7 @@ export class JoinShareDealInput {
   @Field(() => ID)
   shareDealId: string;
 
-  toCommand(userId: string) {
+  toCommand(userId: UserId) {
     return new JoinShareDealCommand(userId, this.shareDealId);
   }
 }

--- a/apps/app/src/module/share-deal/adapter/in/gql/input/LeaveShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/LeaveShareDealInput.ts
@@ -1,5 +1,6 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { EndShareDealCommand } from '../../../../application/port/in/dto/EndShareDealCommand';
 
 @InputType()
@@ -7,7 +8,7 @@ export class LeaveShareDealInput {
   @Field(() => ID)
   shareDealId: string;
 
-  toCommand(userId: string) {
+  toCommand(userId: UserId) {
     return new EndShareDealCommand(userId, this.shareDealId);
   }
 }

--- a/apps/app/src/module/share-deal/adapter/in/gql/input/OpenShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/OpenShareDealInput.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { IsPositive, Min, ValidateNested } from 'class-validator';
 
 import { CreateShareZoneInput } from './CreateShareZoneInput';
+import { UserId } from '../../../../../user/domain/User';
 import { OpenShareDealCommand } from '../../../../application/port/in/dto/OpenShareDealCommand';
 import { FoodCategory } from '../../../../domain/vo/FoodCategory';
 
@@ -33,7 +34,7 @@ export class OpenShareDealInput {
   @ValidateNested()
   shareZone: CreateShareZoneInput;
 
-  toCommand(userId: string): OpenShareDealCommand {
+  toCommand(userId: UserId): OpenShareDealCommand {
     return new OpenShareDealCommand(
       userId,
       this.title,

--- a/apps/app/src/module/share-deal/adapter/in/gql/input/StartShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/StartShareDealInput.ts
@@ -1,5 +1,6 @@
 import { Field, ID, InputType } from '@nestjs/graphql';
 
+import { UserId } from '../../../../../user/domain/User';
 import { StartShareDealCommand } from '../../../../application/port/in/dto/StartShareDealCommand';
 
 @InputType()
@@ -7,7 +8,7 @@ export class StartShareDealInput {
   @Field(() => ID)
   shareDealId: string;
 
-  toCommand(userId: string) {
+  toCommand(userId: UserId) {
     return new StartShareDealCommand(userId, this.shareDealId);
   }
 }

--- a/apps/app/src/module/share-deal/adapter/in/gql/input/UpdateShareDealInput.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/input/UpdateShareDealInput.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { IsPositive, Min, ValidateNested } from 'class-validator';
 
 import { CreateShareZoneInput } from './CreateShareZoneInput';
+import { UserId } from '../../../../../user/domain/User';
 import { UpdateShareDealCommand } from '../../../../application/port/in/dto/UpdateShareDealCommand';
 import { FoodCategory } from '../../../../domain/vo/FoodCategory';
 
@@ -36,7 +37,7 @@ export class UpdateShareDealInput {
   @ValidateNested()
   shareZone: CreateShareZoneInput;
 
-  toCommand(userId: string): UpdateShareDealCommand {
+  toCommand(userId: UserId): UpdateShareDealCommand {
     return new UpdateShareDealCommand(
       userId,
       this.id,

--- a/apps/app/src/module/share-deal/adapter/in/gql/response/ShareDealStatusResponse.ts
+++ b/apps/app/src/module/share-deal/adapter/in/gql/response/ShareDealStatusResponse.ts
@@ -2,7 +2,7 @@ import { NotFoundException } from '@app/domain/exception/NotFoundException';
 import { Field, ObjectType } from '@nestjs/graphql';
 
 import { ShareDealParticipantResponse } from './ShareDealParticipantResponse';
-import { User } from '../../../../../user/domain/User';
+import { User, UserId } from '../../../../../user/domain/User';
 import { ShareDeal } from '../../../../domain/ShareDeal';
 
 @ObjectType()
@@ -19,7 +19,7 @@ export class ShareDealStatusResponse {
   @Field(() => [ShareDealParticipantResponse])
   participants: ShareDealParticipantResponse[];
 
-  static of(shareDeal: ShareDeal, users: User[], userId: string) {
+  static of(shareDeal: ShareDeal, users: User[], userId: UserId) {
     const response = new ShareDealStatusResponse();
     response.canStart = shareDeal.canStart(shareDeal.ownerId);
     response.canEnd = shareDeal.canEnd(shareDeal.ownerId);

--- a/apps/app/src/module/share-deal/adapter/out/persistence/ShareDealOrmMapper.ts
+++ b/apps/app/src/module/share-deal/adapter/out/persistence/ShareDealOrmMapper.ts
@@ -1,5 +1,6 @@
 import { ShareDeal as OrmShareDeal } from '@prisma/client';
 
+import { UserId } from '../../../../user/domain/User';
 import { AddressSystem } from '../../../../user/domain/vo/AddressSystem';
 import { ShareDeal } from '../../../domain/ShareDeal';
 import { FoodCategory } from '../../../domain/vo/FoodCategory';
@@ -12,7 +13,7 @@ export class ShareDealOrmMapper {
     return new ShareDeal({
       category: FoodCategory[orm.category as FoodCategory],
       orderPrice: orm.orderPrice,
-      ownerId: orm.ownerId,
+      ownerId: orm.ownerId as UserId,
       storeName: orm.storeName,
       thumbnail: orm.thumbnail,
       title: orm.title,
@@ -25,7 +26,7 @@ export class ShareDealOrmMapper {
         orm.zone.coordinate.coordinates[0],
       ),
       participantInfo: ParticipantInfo.of(
-        orm.participants.ids,
+        orm.participants.ids as UserId[],
         orm.participants.max,
       ),
     }).setBase(orm.id, orm.createdAt, orm.updatedAt);

--- a/apps/app/src/module/share-deal/adapter/out/persistence/ShareDealQueryRepositoryAdapter.ts
+++ b/apps/app/src/module/share-deal/adapter/out/persistence/ShareDealQueryRepositoryAdapter.ts
@@ -8,6 +8,7 @@ import { pipe, unsafeCoerce } from 'fp-ts/function';
 import { TaskEither } from 'fp-ts/TaskEither';
 
 import { ShareDealOrmMapper } from './ShareDealOrmMapper';
+import { UserId } from '../../../../user/domain/User';
 import { CountShareDealCommand } from '../../../application/port/out/dto/CountShareDealCommand';
 import { FindByUserShareDealCommand } from '../../../application/port/out/dto/FindByUserShareDealCommand';
 import { FindShareDealByNearestCommand } from '../../../application/port/out/dto/FindShareDealByNearestCommand';
@@ -134,7 +135,7 @@ export class ShareDealQueryRepositoryAdapter extends ShareDealQueryRepositoryPor
   }
 
   override countByStatus(
-    userId: string,
+    userId: UserId,
     status: ShareDealStatus,
   ): TaskEither<DBError, number> {
     return tryCatchDB(async () =>

--- a/apps/app/src/module/share-deal/application/port/in/ShareDealQueryUseCase.ts
+++ b/apps/app/src/module/share-deal/application/port/in/ShareDealQueryUseCase.ts
@@ -3,18 +3,19 @@ import { NotFoundException } from '@app/domain/exception/NotFoundException';
 import { TaskEither } from 'fp-ts/TaskEither';
 
 import { ShareDealAccessDeniedException } from './exception/ShareDealAccessDeniedException';
+import { UserId } from '../../../../user/domain/User';
 
 export abstract class ShareDealQueryUseCase {
   abstract isParticipant(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError | ShareDealAccessDeniedException, void>;
 
   abstract participantIds(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<
     DBError | NotFoundException | ShareDealAccessDeniedException,
-    string[]
+    UserId[]
   >;
 }

--- a/apps/app/src/module/share-deal/application/port/in/dto/EndShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/EndShareDealCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../../user/domain/User';
+
 export class EndShareDealCommand {
-  constructor(readonly userId: string, readonly shareDealId: string) {}
+  constructor(readonly userId: UserId, readonly shareDealId: string) {}
 }

--- a/apps/app/src/module/share-deal/application/port/in/dto/JoinShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/JoinShareDealCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../../user/domain/User';
+
 export class JoinShareDealCommand {
-  constructor(readonly userId: string, readonly shareDealId: string) {}
+  constructor(readonly userId: UserId, readonly shareDealId: string) {}
 }

--- a/apps/app/src/module/share-deal/application/port/in/dto/LeaveShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/LeaveShareDealCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../../user/domain/User';
+
 export class LeaveShareDealCommand {
-  constructor(readonly userId: string, readonly shareDealId: string) {}
+  constructor(readonly userId: UserId, readonly shareDealId: string) {}
 }

--- a/apps/app/src/module/share-deal/application/port/in/dto/OpenShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/OpenShareDealCommand.ts
@@ -1,3 +1,4 @@
+import { UserId } from '../../../../../user/domain/User';
 import { AddressSystem } from '../../../../../user/domain/vo/AddressSystem';
 import { ShareDeal } from '../../../../domain/ShareDeal';
 import { FoodCategory } from '../../../../domain/vo/FoodCategory';
@@ -5,7 +6,7 @@ import { ShareZone } from '../../../../domain/vo/ShareZone';
 
 export class OpenShareDealCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly title: string,
     readonly category: FoodCategory,
     readonly maxParticipants: number,

--- a/apps/app/src/module/share-deal/application/port/in/dto/StartShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/StartShareDealCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../../user/domain/User';
+
 export class StartShareDealCommand {
-  constructor(readonly userId: string, readonly shareDealId: string) {}
+  constructor(readonly userId: UserId, readonly shareDealId: string) {}
 }

--- a/apps/app/src/module/share-deal/application/port/in/dto/UpdateShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/in/dto/UpdateShareDealCommand.ts
@@ -1,10 +1,11 @@
+import { UserId } from '../../../../../user/domain/User';
 import { AddressSystem } from '../../../../../user/domain/vo/AddressSystem';
 import { UpdateShareDealProps } from '../../../../domain/ShareDeal';
 import { FoodCategory } from '../../../../domain/vo/FoodCategory';
 
 export class UpdateShareDealCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly shareDealId: string,
     readonly title: string,
     readonly category: FoodCategory,

--- a/apps/app/src/module/share-deal/application/port/out/ShareDealQueryRepositoryPort.ts
+++ b/apps/app/src/module/share-deal/application/port/out/ShareDealQueryRepositoryPort.ts
@@ -6,6 +6,7 @@ import { CountShareDealCommand } from './dto/CountShareDealCommand';
 import { FindByUserShareDealCommand } from './dto/FindByUserShareDealCommand';
 import { FindShareDealByNearestCommand } from './dto/FindShareDealByNearestCommand';
 import { FindShareDealCommand } from './dto/FindShareDealCommand';
+import { UserId } from '../../../../user/domain/User';
 import { ShareDeal } from '../../../domain/ShareDeal';
 import { ShareDealStatus } from '../../../domain/vo/ShareDealStatus';
 
@@ -29,7 +30,7 @@ export abstract class ShareDealQueryRepositoryPort {
   ): TaskEither<DBError | NotFoundException, ShareDeal>;
 
   abstract countByStatus(
-    userId: string,
+    userId: UserId,
     status: ShareDealStatus,
   ): TaskEither<DBError, number>;
 }

--- a/apps/app/src/module/share-deal/application/port/out/dto/FindByUserShareDealCommand.ts
+++ b/apps/app/src/module/share-deal/application/port/out/dto/FindByUserShareDealCommand.ts
@@ -1,10 +1,11 @@
 import { PageCommand } from '@app/domain/command/PageCommand';
 
+import { UserId } from '../../../../../user/domain/User';
 import { ShareDealStatus } from '../../../../domain/vo/ShareDealStatus';
 
 export class FindByUserShareDealCommand extends PageCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly status: ShareDealStatus,
     page?: number,
     size?: number,

--- a/apps/app/src/module/share-deal/application/service/ShareDealQueryService.ts
+++ b/apps/app/src/module/share-deal/application/service/ShareDealQueryService.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { constVoid, pipe } from 'fp-ts/function';
 import { TaskEither } from 'fp-ts/TaskEither';
 
+import { UserId } from '../../../user/domain/User';
 import { ShareDealAccessDeniedException } from '../port/in/exception/ShareDealAccessDeniedException';
 import { ShareDealQueryUseCase } from '../port/in/ShareDealQueryUseCase';
 import { ShareDealQueryRepositoryPort } from '../port/out/ShareDealQueryRepositoryPort';
@@ -19,7 +20,7 @@ export class ShareDealQueryService extends ShareDealQueryUseCase {
 
   override isParticipant(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError | ShareDealAccessDeniedException, void> {
     return pipe(
       this.shareDealQueryRepositoryPort.findById(shareDealId),
@@ -33,10 +34,10 @@ export class ShareDealQueryService extends ShareDealQueryUseCase {
 
   override participantIds(
     shareDealId: string,
-    userId: string,
+    userId: UserId,
   ): TaskEither<
     DBError | NotFoundException | ShareDealAccessDeniedException,
-    string[]
+    UserId[]
   > {
     return pipe(
       this.shareDealQueryRepositoryPort.findById(shareDealId),

--- a/apps/app/src/module/share-deal/domain/vo/ParticipantInfo.ts
+++ b/apps/app/src/module/share-deal/domain/vo/ParticipantInfo.ts
@@ -1,6 +1,8 @@
+import { UserId } from '../../../user/domain/User';
+
 export class ParticipantInfo {
   constructor(
-    readonly ids: string[],
+    readonly ids: UserId[],
     readonly max: number,
     readonly current: number,
     readonly remaining: number,
@@ -14,7 +16,7 @@ export class ParticipantInfo {
     return this.remaining > 0;
   }
 
-  static of(ids: string[], max: number): ParticipantInfo {
+  static of(ids: UserId[], max: number): ParticipantInfo {
     return new ParticipantInfo(
       ids,
       max,
@@ -23,7 +25,7 @@ export class ParticipantInfo {
     );
   }
 
-  addId(id: string): ParticipantInfo {
+  addId(id: UserId): ParticipantInfo {
     if (this.hasId(id)) {
       return this;
     }
@@ -45,7 +47,7 @@ export class ParticipantInfo {
     );
   }
 
-  hasId(id: string) {
+  hasId(id: UserId) {
     return this.ids.includes(id);
   }
 

--- a/apps/app/src/module/user-push-token/adapter/out/persistence/UserPushTokenOrmMapper.ts
+++ b/apps/app/src/module/user-push-token/adapter/out/persistence/UserPushTokenOrmMapper.ts
@@ -1,12 +1,13 @@
 import { UserPushToken as OrmUserPushToken } from '@prisma/client';
 
+import { UserId } from '../../../../user/domain/User';
 import { UserPushToken } from '../../../domain/UserPushToken';
 
 export class UserPushTokenOrmMapper {
   static toDomain(orm: OrmUserPushToken): UserPushToken {
     return new UserPushToken({
       token: orm.token,
-      userId: orm.userId,
+      userId: orm.userId as UserId,
     }).setBase(orm.id, orm.createdAt, orm.updatedAt);
   }
 

--- a/apps/app/src/module/user-push-token/domain/UserPushToken.ts
+++ b/apps/app/src/module/user-push-token/domain/UserPushToken.ts
@@ -1,7 +1,9 @@
 import { BaseEntity } from '@app/domain/entity/BaseEntity';
 
+import { UserId } from '../../user/domain/User';
+
 export interface UserPushTokenProps {
-  userId: string;
+  userId: UserId;
   token: string;
 }
 

--- a/apps/app/src/module/user/adapter/in/gql/UserQueryResolver.ts
+++ b/apps/app/src/module/user/adapter/in/gql/UserQueryResolver.ts
@@ -8,6 +8,7 @@ import { MyProfileResponse } from './response/MyProfileResponse';
 import { UserAddressResponse } from './response/UserAddressResponse';
 import { UserProfileResponse } from './response/UserProfileResponse';
 import { UserQueryRepositoryPort } from '../../../application/port/out/UserQueryRepositoryPort';
+import { UserId } from '../../../domain/User';
 
 @Resolver()
 export class UserQueryResolver {
@@ -46,7 +47,7 @@ export class UserQueryResolver {
 
   @Query(() => UserProfileResponse, { description: '프로필 정보' })
   async profile(
-    @Args('userId', { type: () => ID }) userId: string,
+    @Args('userId', { type: () => ID }) userId: UserId,
   ): Promise<UserProfileResponse> {
     return pipe(
       this.userQueryRepositoryPort.findById(userId),

--- a/apps/app/src/module/user/adapter/in/gql/auth/JwtStrategy.ts
+++ b/apps/app/src/module/user/adapter/in/gql/auth/JwtStrategy.ts
@@ -2,6 +2,7 @@ import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 
 import { Session } from './Session';
+import { UserId } from '../../../../domain/User';
 
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(jwtSecret: string) {
@@ -13,6 +14,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: { id: string }): Promise<Session> {
-    return new Session(payload.id);
+    return new Session(UserId(payload.id));
   }
 }

--- a/apps/app/src/module/user/adapter/in/gql/auth/Session.ts
+++ b/apps/app/src/module/user/adapter/in/gql/auth/Session.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../domain/User';
+
 export class Session {
-  constructor(readonly id: string) {}
+  constructor(readonly id: UserId) {}
 }

--- a/apps/app/src/module/user/adapter/in/gql/input/AddressInput.ts
+++ b/apps/app/src/module/user/adapter/in/gql/input/AddressInput.ts
@@ -4,6 +4,7 @@ import { IsNotEmpty, ValidateIf, ValidateNested } from 'class-validator';
 
 import { CoordinateInput } from './CoordinateInput';
 import { AppendAddressCommand } from '../../../../application/port/in/dto/AppendAddressCommand';
+import { UserId } from '../../../../domain/User';
 import { AddressSystem } from '../../../../domain/vo/AddressSystem';
 import { AddressType } from '../../../../domain/vo/AddressType';
 
@@ -31,7 +32,7 @@ export class AddressInput {
   @ValidateNested()
   coordinate: CoordinateInput;
 
-  toCommand(userId: string): AppendAddressCommand {
+  toCommand(userId: UserId): AppendAddressCommand {
     return new AppendAddressCommand(
       userId,
       this.coordinate.latitude,

--- a/apps/app/src/module/user/adapter/in/gql/input/EnrollUserInput.ts
+++ b/apps/app/src/module/user/adapter/in/gql/input/EnrollUserInput.ts
@@ -4,6 +4,7 @@ import { ValidateNested } from 'class-validator';
 
 import { AddressInput } from './AddressInput';
 import { EnrollUserCommand } from '../../../../application/port/in/dto/EnrollUserCommand';
+import { UserId } from '../../../../domain/User';
 
 @InputType()
 export class EnrollUserInput {
@@ -15,7 +16,7 @@ export class EnrollUserInput {
   @ValidateNested()
   address: AddressInput;
 
-  toCommand(userId: string) {
+  toCommand(userId: UserId) {
     return new EnrollUserCommand(
       userId,
       this.nickname,

--- a/apps/app/src/module/user/adapter/in/gql/input/LeaveUserInput.ts
+++ b/apps/app/src/module/user/adapter/in/gql/input/LeaveUserInput.ts
@@ -3,6 +3,7 @@ import { IsNotEmpty, ValidateIf } from 'class-validator';
 
 import { LeaveReasonType } from './LeaveReasonType';
 import { LeaveUserCommand } from '../../../../application/port/in/dto/LeaveUserCommand';
+import { UserId } from '../../../../domain/User';
 
 @InputType()
 export class LeaveUserInput {
@@ -17,7 +18,7 @@ export class LeaveUserInput {
   @IsNotEmpty()
   body?: string;
 
-  toCommand(userId: string): LeaveUserCommand {
+  toCommand(userId: UserId): LeaveUserCommand {
     return new LeaveUserCommand(userId, this.name, this.toBody());
   }
 

--- a/apps/app/src/module/user/adapter/in/gql/input/SendPhoneVerificationCodeInput.ts
+++ b/apps/app/src/module/user/adapter/in/gql/input/SendPhoneVerificationCodeInput.ts
@@ -1,13 +1,14 @@
 import { Field, InputType } from '@nestjs/graphql';
 
 import { SendPhoneVerificationCodeCommand } from '../../../../application/port/in/dto/SendPhoneVerificationCodeCommand';
+import { UserId } from '../../../../domain/User';
 
 @InputType()
 export class SendPhoneVerificationCodeInput {
   @Field()
   phoneNumber: string;
 
-  toCommand(id: string): SendPhoneVerificationCodeCommand {
-    return new SendPhoneVerificationCodeCommand(id, this.phoneNumber);
+  toCommand(userId: UserId): SendPhoneVerificationCodeCommand {
+    return new SendPhoneVerificationCodeCommand(userId, this.phoneNumber);
   }
 }

--- a/apps/app/src/module/user/adapter/in/gql/input/UpdateProfileInput.ts
+++ b/apps/app/src/module/user/adapter/in/gql/input/UpdateProfileInput.ts
@@ -1,13 +1,14 @@
 import { Field, InputType } from '@nestjs/graphql';
 
 import { UpdateProfileCommand } from '../../../../application/port/in/dto/UpdateProfileCommand';
+import { UserId } from '../../../../domain/User';
 
 @InputType()
 export class UpdateProfileInput {
   @Field()
   introduce: string;
 
-  toCommand(userId: string) {
+  toCommand(userId: UserId) {
     return new UpdateProfileCommand(userId, this.introduce);
   }
 }

--- a/apps/app/src/module/user/adapter/in/gql/input/VerifyPhoneVerificationCodeInput.ts
+++ b/apps/app/src/module/user/adapter/in/gql/input/VerifyPhoneVerificationCodeInput.ts
@@ -1,13 +1,14 @@
 import { Field, InputType } from '@nestjs/graphql';
 
 import { VerifyPhoneVerificationCodeCommand } from '../../../../application/port/in/dto/VerifyPhoneVerificationCodeCommand';
+import { UserId } from '../../../../domain/User';
 
 @InputType()
 export class VerifyPhoneVerificationCodeInput {
   @Field()
   code: string;
 
-  toCommand(id: string): VerifyPhoneVerificationCodeCommand {
-    return new VerifyPhoneVerificationCodeCommand(id, this.code);
+  toCommand(userId: UserId): VerifyPhoneVerificationCodeCommand {
+    return new VerifyPhoneVerificationCodeCommand(userId, this.code);
   }
 }

--- a/apps/app/src/module/user/adapter/out/persistence/PhoneVerificationRepositoryAdapter.ts
+++ b/apps/app/src/module/user/adapter/out/persistence/PhoneVerificationRepositoryAdapter.ts
@@ -8,6 +8,7 @@ import { TaskEither } from 'fp-ts/TaskEither';
 
 import { PhoneVerificationRepositoryPort } from '../../../application/port/out/PhoneVerificationRepositoryPort';
 import { PhoneVerification } from '../../../domain/PhoneVerification';
+import { UserId } from '../../../domain/User';
 
 @Injectable()
 export class PhoneVerificationRepositoryAdapter extends PhoneVerificationRepositoryPort {
@@ -16,7 +17,7 @@ export class PhoneVerificationRepositoryAdapter extends PhoneVerificationReposit
   }
 
   override save(
-    userId: string,
+    userId: UserId,
     phoneVerification: PhoneVerification,
   ): TaskEither<DBError, PhoneVerification> {
     return pipe(
@@ -37,7 +38,7 @@ export class PhoneVerificationRepositoryAdapter extends PhoneVerificationReposit
   }
 
   override findLatest(
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError | NotFoundException, PhoneVerification> {
     return pipe(
       tryCatchDB(() =>

--- a/apps/app/src/module/user/application/port/in/dto/AppendAddressCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/AppendAddressCommand.ts
@@ -1,10 +1,11 @@
+import { UserId } from '../../../../domain/User';
 import { Address } from '../../../../domain/vo/Address';
 import { AddressSystem } from '../../../../domain/vo/AddressSystem';
 import { AddressType } from '../../../../domain/vo/AddressType';
 
 export class AppendAddressCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly latitude: number,
     readonly longitude: number,
     readonly addressType: AddressType,

--- a/apps/app/src/module/user/application/port/in/dto/DeleteAddressCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/DeleteAddressCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../domain/User';
+
 export class DeleteAddressCommand {
-  constructor(readonly key: string, readonly userId: string) {}
+  constructor(readonly key: string, readonly userId: UserId) {}
 }

--- a/apps/app/src/module/user/application/port/in/dto/EnrollUserCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/EnrollUserCommand.ts
@@ -1,10 +1,11 @@
+import { UserId } from '../../../../domain/User';
 import { Address } from '../../../../domain/vo/Address';
 import { AddressSystem } from '../../../../domain/vo/AddressSystem';
 import { AddressType } from '../../../../domain/vo/AddressType';
 
 export class EnrollUserCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly nickname: string,
     readonly latitude: number,
     readonly longitude: number,

--- a/apps/app/src/module/user/application/port/in/dto/LeaveUserCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/LeaveUserCommand.ts
@@ -1,6 +1,8 @@
+import { UserId } from '../../../../domain/User';
+
 export class LeaveUserCommand {
   constructor(
-    readonly userId: string,
+    readonly userId: UserId,
     readonly name: string,
     readonly reason: string,
   ) {}

--- a/apps/app/src/module/user/application/port/in/dto/SendPhoneVerificationCodeCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/SendPhoneVerificationCodeCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../domain/User';
+
 export class SendPhoneVerificationCodeCommand {
-  constructor(readonly id: string, readonly phoneNumber: string) {}
+  constructor(readonly userId: UserId, readonly phoneNumber: string) {}
 }

--- a/apps/app/src/module/user/application/port/in/dto/UpdateProfileCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/UpdateProfileCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../domain/User';
+
 export class UpdateProfileCommand {
-  constructor(readonly userId: string, readonly introduce: string) {}
+  constructor(readonly userId: UserId, readonly introduce: string) {}
 }

--- a/apps/app/src/module/user/application/port/in/dto/VerifyPhoneVerificationCodeCommand.ts
+++ b/apps/app/src/module/user/application/port/in/dto/VerifyPhoneVerificationCodeCommand.ts
@@ -1,3 +1,5 @@
+import { UserId } from '../../../../domain/User';
+
 export class VerifyPhoneVerificationCodeCommand {
-  constructor(readonly userId: string, readonly code: string) {}
+  constructor(readonly userId: UserId, readonly code: string) {}
 }

--- a/apps/app/src/module/user/application/port/out/PhoneVerificationRepositoryPort.ts
+++ b/apps/app/src/module/user/application/port/out/PhoneVerificationRepositoryPort.ts
@@ -3,14 +3,15 @@ import { NotFoundException } from '@app/domain/exception/NotFoundException';
 import { TaskEither } from 'fp-ts/TaskEither';
 
 import { PhoneVerification } from '../../../domain/PhoneVerification';
+import { UserId } from '../../../domain/User';
 
 export abstract class PhoneVerificationRepositoryPort {
   abstract save(
-    userId: string,
+    userId: UserId,
     phoneVerification: PhoneVerification,
   ): TaskEither<DBError, PhoneVerification>;
 
   abstract findLatest(
-    userId: string,
+    userId: UserId,
   ): TaskEither<DBError | NotFoundException, PhoneVerification>;
 }

--- a/apps/app/src/module/user/application/service/PhoneVerificationService.ts
+++ b/apps/app/src/module/user/application/service/PhoneVerificationService.ts
@@ -33,7 +33,7 @@ export class PhoneVerificationService extends PhoneVerificationUseCase {
   ): TaskEither<DBError | NotificationError, void> {
     return pipe(
       this.phoneVerificationRepositoryPort.save(
-        command.id,
+        command.userId,
         PhoneVerification.of(command.phoneNumber),
       ),
       TE.chainW((verification) =>

--- a/apps/app/src/module/user/domain/User.ts
+++ b/apps/app/src/module/user/domain/User.ts
@@ -1,4 +1,5 @@
-import { BaseEntity } from '@app/domain/entity/BaseEntity';
+import { BaseBrandedEntity } from '@app/domain/entity/BaseBrandedEntity';
+import { Branded } from '@app/domain/entity/Branded';
 import { IllegalStateException } from '@app/domain/exception/IllegalStateException';
 import * as E from 'fp-ts/Either';
 import { Either } from 'fp-ts/Either';
@@ -24,7 +25,13 @@ export interface UserProps {
   leaveReason: LeaveReason | null;
 }
 
-export class User extends BaseEntity<UserProps> {
+export type UserId = Branded<string, 'UserId'>;
+
+export function UserId(id: string): UserId {
+  return id as UserId;
+}
+
+export class User extends BaseBrandedEntity<UserProps, UserId> {
   constructor(props: UserProps) {
     super(props);
   }

--- a/apps/app/test/chat/integration/ChatQueryRepositoryAdapter.spec.ts
+++ b/apps/app/test/chat/integration/ChatQueryRepositoryAdapter.spec.ts
@@ -5,6 +5,7 @@ import { ChatOrmMapper } from '../../../src/module/chat/adapter/out/persistence/
 import { ChatQueryRepositoryAdapter } from '../../../src/module/chat/adapter/out/persistence/ChatQueryRepositoryAdapter';
 import { FindChatByUserCommand } from '../../../src/module/chat/application/port/in/dto/FindChatByUserCommand';
 import { MessageType } from '../../../src/module/chat/domain/vo/MessageType';
+import { UserId } from '../../../src/module/user/domain/User';
 import { ChatFactory } from '../../fixture/ChatFactory';
 import {
   assertNone,
@@ -26,7 +27,7 @@ describe('ChatQueryRepositoryAdapter', () => {
     it('작성된 채팅이 없는 경우 빈 채팅 목록이 반환된다.', async () => {
       // given
       const shareDealId = faker.database.mongodbObjectId();
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
 
       // when
       const result = chatQueryRepositoryAdapter.last(shareDealId, userId);
@@ -40,7 +41,7 @@ describe('ChatQueryRepositoryAdapter', () => {
     it('채팅방에 작성된 마지막 메시지를 조회한다.', async () => {
       // given
       const shareDealId = faker.database.mongodbObjectId();
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       await prisma.chat.createMany({
         data: [
           {
@@ -86,7 +87,7 @@ describe('ChatQueryRepositoryAdapter', () => {
     it('작성된 채팅이 없는 경우 0이 반환된다.', async () => {
       // given
       const shareDealId = faker.database.mongodbObjectId();
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
 
       // when
       const result = chatQueryRepositoryAdapter.unreadCount(
@@ -103,7 +104,7 @@ describe('ChatQueryRepositoryAdapter', () => {
     it('채팅방의 안읽은 메시지의 개수를 조회한다.', async () => {
       // given
       const shareDealId = faker.database.mongodbObjectId();
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
 
       await prisma.chat.createMany({
         data: [true, true, false, true].map((unread) => ({
@@ -136,7 +137,7 @@ describe('ChatQueryRepositoryAdapter', () => {
     it('주어진 사용자의 채팅목록을 가져온다', async () => {
       // given
       const shareDealId = faker.database.mongodbObjectId();
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       const chats = [
         ChatFactory.create({
           shareDealId,

--- a/apps/app/test/chat/integration/ChatRepositoryAdapter.spec.ts
+++ b/apps/app/test/chat/integration/ChatRepositoryAdapter.spec.ts
@@ -5,6 +5,7 @@ import { ChatOrmMapper } from '../../../src/module/chat/adapter/out/persistence/
 import { ChatRepositoryAdapter } from '../../../src/module/chat/adapter/out/persistence/ChatRepositoryAdapter';
 import { Chat } from '../../../src/module/chat/domain/Chat';
 import { Message } from '../../../src/module/chat/domain/vo/Message';
+import { UserId } from '../../../src/module/user/domain/User';
 import { assertResolvesRight } from '../../fixture/utils';
 
 describe('ChatRepositoryAdapter', () => {
@@ -19,16 +20,18 @@ describe('ChatRepositoryAdapter', () => {
       const chats = [
         Chat.of({
           shareDealId: faker.database.mongodbObjectId(),
-          userId: faker.database.mongodbObjectId(),
+          userId: UserId(faker.database.mongodbObjectId()),
           orderedKey: faker.random.numeric(),
-          message: Message.firstMessage(faker.database.mongodbObjectId()),
+          message: Message.firstMessage(
+            UserId(faker.database.mongodbObjectId()),
+          ),
         }),
         Chat.of({
           shareDealId: faker.database.mongodbObjectId(),
-          userId: faker.database.mongodbObjectId(),
+          userId: UserId(faker.database.mongodbObjectId()),
           orderedKey: faker.random.numeric(),
           message: Message.startShareDealMessage(
-            faker.database.mongodbObjectId(),
+            UserId(faker.database.mongodbObjectId()),
           ),
         }),
       ];
@@ -53,14 +56,14 @@ describe('ChatRepositoryAdapter', () => {
     it('주어진 채팅을 모두 읽음처리한다', async () => {
       // given
       const shareDealId = faker.database.mongodbObjectId();
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       const chats = [
         Chat.of({
           shareDealId,
           userId,
           orderedKey: faker.random.numeric(),
           message: Message.normal(
-            faker.database.mongodbObjectId(),
+            UserId(faker.database.mongodbObjectId()),
             'content 1',
             true,
           ),
@@ -70,7 +73,7 @@ describe('ChatRepositoryAdapter', () => {
           userId,
           orderedKey: faker.random.numeric(),
           message: Message.normal(
-            faker.database.mongodbObjectId(),
+            UserId(faker.database.mongodbObjectId()),
             'content 2',
             true,
           ),

--- a/apps/app/test/chat/unit/ChatCommandService.spec.ts
+++ b/apps/app/test/chat/unit/ChatCommandService.spec.ts
@@ -10,6 +10,7 @@ import { Chat } from '../../../src/module/chat/domain/Chat';
 import { ChatWrittenEvent } from '../../../src/module/chat/domain/event/ChatWrittenEvent';
 import { ShareDealAccessDeniedException } from '../../../src/module/share-deal/application/port/in/exception/ShareDealAccessDeniedException';
 import { ShareDealQueryUseCase } from '../../../src/module/share-deal/application/port/in/ShareDealQueryUseCase';
+import { UserId } from '../../../src/module/user/domain/User';
 import { assertResolvesLeft, assertResolvesRight } from '../../fixture/utils';
 
 describe('ChatCommandService', () => {
@@ -34,7 +35,11 @@ describe('ChatCommandService', () => {
   describe('write', () => {
     it('공유딜 권한이 없으면 에러가 발생한다', async () => {
       // given
-      const command = new WriteChatCommand('userId', 'shareDealId', 'content');
+      const command = new WriteChatCommand(
+        UserId('userId'),
+        'shareDealId',
+        'content',
+      );
 
       shareDealQueryUseCase.participantIds.mockReturnValue(
         left(new ShareDealAccessDeniedException('error')),
@@ -51,11 +56,15 @@ describe('ChatCommandService', () => {
 
     it('참여자에게 모두 채팅을 추가한다', async () => {
       // given
-      const command = new WriteChatCommand('user 1', 'shareDealId', 'content');
+      const command = new WriteChatCommand(
+        UserId('user 1'),
+        'shareDealId',
+        'content',
+      );
       let db: Chat[] = [];
 
       shareDealQueryUseCase.participantIds.mockReturnValue(
-        right(['user 1', 'user 2', 'user 3']),
+        right(['user 1', 'user 2', 'user 3'].map(UserId)),
       );
       chatRepositoryPort.create.mockImplementation((chats) => {
         db = chats;
@@ -106,10 +115,14 @@ describe('ChatCommandService', () => {
 
     it('채팅 작성 이벤트를 발송한다', async () => {
       // given
-      const command = new WriteChatCommand('user 1', 'shareDealId', 'content');
+      const command = new WriteChatCommand(
+        UserId('user 1'),
+        'shareDealId',
+        'content',
+      );
 
       shareDealQueryUseCase.participantIds.mockReturnValue(
-        right(['user 1', 'user 2', 'user 3']),
+        right(['user 1', 'user 2', 'user 3'].map(UserId)),
       );
       chatRepositoryPort.create.mockImplementation((chats) => right(chats));
 

--- a/apps/app/test/chat/unit/ChatEventListener.spec.ts
+++ b/apps/app/test/chat/unit/ChatEventListener.spec.ts
@@ -14,6 +14,7 @@ import { ShareDealClosedEvent } from '../../../src/module/share-deal/domain/even
 import { ShareDealEndedEvent } from '../../../src/module/share-deal/domain/event/ShareDealEndedEvent';
 import { ShareDealStartedEvent } from '../../../src/module/share-deal/domain/event/ShareDealStartedEvent';
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
+import { UserId } from '../../../src/module/user/domain/User';
 import { ChatFactory } from '../../fixture/ChatFactory';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 
@@ -60,8 +61,8 @@ describe('ChatEventListener', () => {
       const shareDealId = '1234';
       const shareDeal = ShareDealFactory.create({
         id: shareDealId,
-        ownerId: 'ownerId',
-        participantInfo: ParticipantInfo.of(['participantId'], 3),
+        ownerId: UserId('ownerId'),
+        participantInfo: ParticipantInfo.of(['participantId'].map(UserId), 3),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));
@@ -104,8 +105,8 @@ describe('ChatEventListener', () => {
       const shareDealId = '1234';
       const shareDeal = ShareDealFactory.create({
         id: shareDealId,
-        ownerId: 'ownerId',
-        participantInfo: ParticipantInfo.of(['participantId'], 3),
+        ownerId: UserId('ownerId'),
+        participantInfo: ParticipantInfo.of(['participantId'].map(UserId), 3),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));
@@ -146,8 +147,8 @@ describe('ChatEventListener', () => {
       const shareDealId = '1234';
       const shareDeal = ShareDealFactory.create({
         id: shareDealId,
-        ownerId: 'ownerId',
-        participantInfo: ParticipantInfo.of(['participantId'], 3),
+        ownerId: UserId('ownerId'),
+        participantInfo: ParticipantInfo.of(['participantId'].map(UserId), 3),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));

--- a/apps/app/test/chat/unit/ChatQueryResolver.spec.ts
+++ b/apps/app/test/chat/unit/ChatQueryResolver.spec.ts
@@ -11,6 +11,7 @@ import { FindByUserDto } from '../../../src/module/chat/application/port/in/dto/
 import { FindChatResult } from '../../../src/module/chat/application/port/in/dto/FindChatResult';
 import { Message } from '../../../src/module/chat/domain/vo/Message';
 import { ShareDealStatus } from '../../../src/module/share-deal/domain/vo/ShareDealStatus';
+import { UserId } from '../../../src/module/user/domain/User';
 import { ChatFactory } from '../../fixture/ChatFactory';
 import {
   graphQLTestHelper,
@@ -110,7 +111,7 @@ describe('ChatQueryResolver', () => {
       const chatByUserDto = new FindByUserDto(
         ChatFactory.create({
           id: 'id',
-          message: Message.normal('id', 'content', true),
+          message: Message.normal(UserId('id'), 'content', true),
         }),
         UserFactory.create({ id: 'id', nickname: 'nickname' }),
       );

--- a/apps/app/test/chat/unit/ChatQueryService.spec.ts
+++ b/apps/app/test/chat/unit/ChatQueryService.spec.ts
@@ -13,6 +13,7 @@ import { Message } from '../../../src/module/chat/domain/vo/Message';
 import { ShareDealQueryRepositoryPort } from '../../../src/module/share-deal/application/port/out/ShareDealQueryRepositoryPort';
 import { ShareDealStatus } from '../../../src/module/share-deal/domain/vo/ShareDealStatus';
 import { UserQueryRepositoryPort } from '../../../src/module/user/application/port/out/UserQueryRepositoryPort';
+import { UserId } from '../../../src/module/user/domain/User';
 import { ChatFactory } from '../../fixture/ChatFactory';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 import { UserFactory } from '../../fixture/UserFactory';
@@ -51,9 +52,9 @@ describe('ChatQueryService', () => {
       const chats = shareDeals.map((deal) =>
         Chat.of({
           shareDealId: deal.id,
-          userId: 'userId',
+          userId: UserId('userId'),
           orderedKey: 'orderedKey',
-          message: Message.normal('123', 'content', true),
+          message: Message.normal(UserId('123'), 'content', true),
         }),
       );
 
@@ -68,7 +69,7 @@ describe('ChatQueryService', () => {
       );
 
       const command = new FindChatCommand(
-        'userId',
+        UserId('userId'),
         ShareDealStatus.START,
         1,
         10,
@@ -107,7 +108,10 @@ describe('ChatQueryService', () => {
       chatQueryRepositoryPort.findByUser.mockReturnValue(right([]));
       userQueryRepositoryPort.findByIds.mockReturnValue(right([]));
 
-      const command = new FindChatByUserCommand('shareDealId', 'userId');
+      const command = new FindChatByUserCommand(
+        'shareDealId',
+        UserId('userId'),
+      );
 
       // when
       const result = shareDealCommandService.findByUser(command);
@@ -129,7 +133,10 @@ describe('ChatQueryService', () => {
       chatQueryRepositoryPort.findByUser.mockReturnValue(right([chat]));
       userQueryRepositoryPort.findByIds.mockReturnValue(right([user]));
 
-      const command = new FindChatByUserCommand('shareDealId', 'userId');
+      const command = new FindChatByUserCommand(
+        'shareDealId',
+        UserId('userId'),
+      );
 
       // when
       const result = shareDealCommandService.findByUser(command);

--- a/apps/app/test/fixture/ChatFactory.ts
+++ b/apps/app/test/fixture/ChatFactory.ts
@@ -3,6 +3,7 @@ import { faker } from '@faker-js/faker';
 import { Chat, ChatProps } from '../../src/module/chat/domain/Chat';
 import { Message } from '../../src/module/chat/domain/vo/Message';
 import { MessageType } from '../../src/module/chat/domain/vo/MessageType';
+import { UserId } from '../../src/module/user/domain/User';
 
 type BaseType = {
   id?: string;
@@ -13,7 +14,7 @@ type BaseType = {
 export class ChatFactory {
   static create(props: Partial<ChatProps & BaseType> = {}): Chat {
     const message = Message.of(
-      faker.database.mongodbObjectId(),
+      UserId(faker.database.mongodbObjectId()),
       faker.helpers.arrayElement([MessageType.NORMAL, MessageType.NOTICE]),
       faker.lorem.sentence(),
       faker.datatype.boolean(),
@@ -21,7 +22,7 @@ export class ChatFactory {
 
     return new Chat({
       shareDealId: faker.database.mongodbObjectId(),
-      userId: faker.database.mongodbObjectId(),
+      userId: UserId(faker.database.mongodbObjectId()),
       orderedKey: faker.random.numeric(),
       message,
       ...props,

--- a/apps/app/test/fixture/ShareDealFactory.ts
+++ b/apps/app/test/fixture/ShareDealFactory.ts
@@ -8,6 +8,7 @@ import { FoodCategory } from '../../src/module/share-deal/domain/vo/FoodCategory
 import { ParticipantInfo } from '../../src/module/share-deal/domain/vo/ParticipantInfo';
 import { ShareDealStatus } from '../../src/module/share-deal/domain/vo/ShareDealStatus';
 import { ShareZone } from '../../src/module/share-deal/domain/vo/ShareZone';
+import { UserId } from '../../src/module/user/domain/User';
 import { AddressSystem } from '../../src/module/user/domain/vo/AddressSystem';
 
 type BaseType = {
@@ -26,7 +27,7 @@ export class ShareDealFactory {
       +faker.address.latitude(undefined, 0),
       +faker.address.longitude(undefined, 0),
     );
-    const ownerId = props.ownerId ?? faker.database.mongodbObjectId();
+    const ownerId = UserId(props.ownerId ?? faker.database.mongodbObjectId());
 
     return new ShareDeal({
       title: faker.word.noun(3),

--- a/apps/app/test/fixture/graphqlTestHelper.ts
+++ b/apps/app/test/fixture/graphqlTestHelper.ts
@@ -12,10 +12,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 
 import { CategoryQueryResolver } from '../../src/module/category/adapter/in/gql/CategoryQueryResolver';
 import { Session } from '../../src/module/user/adapter/in/gql/auth/Session';
+import { UserId } from '../../src/module/user/domain/User';
 
-let userId: string | undefined;
+let userId: UserId | undefined;
 
-export function setMockUser(id = 'userId') {
+export function setMockUser(id = UserId('userId')) {
   userId = id;
 }
 
@@ -28,7 +29,7 @@ export class MockGuard implements CanActivate {
     if (userId) {
       const ctx = GqlExecutionContext.create(context);
       const request = ctx.getContext().req;
-      request.user = new Session(userId);
+      request.user = new Session(UserId(userId));
     }
 
     return true;

--- a/apps/app/test/share-deal/integration/ShareDealQueryRepositoryAdapter.spec.ts
+++ b/apps/app/test/share-deal/integration/ShareDealQueryRepositoryAdapter.spec.ts
@@ -13,6 +13,7 @@ import { FoodCategory } from '../../../src/module/share-deal/domain/vo/FoodCateg
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
 import { ShareDealStatus } from '../../../src/module/share-deal/domain/vo/ShareDealStatus';
 import { ShareZone } from '../../../src/module/share-deal/domain/vo/ShareZone';
+import { UserId } from '../../../src/module/user/domain/User';
 import { AddressSystem } from '../../../src/module/user/domain/vo/AddressSystem';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 import { assertResolvesLeft, assertResolvesRight } from '../../fixture/utils';
@@ -377,7 +378,7 @@ describe('ShareDealQueryRepositoryAdapter', () => {
   describe('countByStatus', () => {
     it('주어진 상태에 대한 공유딜이 없으면 0을 반환한다', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
 
       // when
       const result = shareDealRepositoryAdapter.countByStatus(
@@ -393,7 +394,7 @@ describe('ShareDealQueryRepositoryAdapter', () => {
 
     it('내가 만든 공유딜 개수를 가져온다', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       await prisma.shareDeal.createMany({
         data: [
           ShareDealStatus.START,
@@ -419,7 +420,7 @@ describe('ShareDealQueryRepositoryAdapter', () => {
 
     it('내가 참여한 공유딜 개수를 가져온다', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       await prisma.shareDeal.create({
         data: ShareDealOrmMapper.toOrm(
           ShareDealFactory.create({
@@ -482,7 +483,7 @@ describe('ShareDealQueryRepositoryAdapter', () => {
       });
 
       const command = new FindByUserShareDealCommand(
-        faker.database.mongodbObjectId(),
+        UserId(faker.database.mongodbObjectId()),
         ShareDealStatus.OPEN,
       );
 
@@ -497,12 +498,12 @@ describe('ShareDealQueryRepositoryAdapter', () => {
 
     it('지정된 상태가 아닌 공유딜의 경우 참여 여부와 상관없이 조회되지 않는다.', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       await prisma.shareDeal.create({
         data: ShareDealOrmMapper.toOrm(
           ShareDealFactory.create({
             status: ShareDealStatus.START,
-            participantInfo: ParticipantInfo.of([userId], 3),
+            participantInfo: ParticipantInfo.of([userId].map(UserId), 3),
           }),
         ),
       });
@@ -523,7 +524,7 @@ describe('ShareDealQueryRepositoryAdapter', () => {
 
     it('참여중인 공유딜 중에서 지정된 상태의 공유딜 목록을 조회한다.', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       await prisma.shareDeal.create({
         data: ShareDealOrmMapper.toOrm(
           ShareDealFactory.create({

--- a/apps/app/test/share-deal/integration/ShareDealRepositoryAdapter.spec.ts
+++ b/apps/app/test/share-deal/integration/ShareDealRepositoryAdapter.spec.ts
@@ -8,6 +8,7 @@ import { ShareDealStartedEvent } from '../../../src/module/share-deal/domain/eve
 import { ShareDeal } from '../../../src/module/share-deal/domain/ShareDeal';
 import { FoodCategory } from '../../../src/module/share-deal/domain/vo/FoodCategory';
 import { ShareZone } from '../../../src/module/share-deal/domain/vo/ShareZone';
+import { UserId } from '../../../src/module/user/domain/User';
 import { AddressSystem } from '../../../src/module/user/domain/vo/AddressSystem';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 import { assertResolvesRight } from '../../fixture/utils';
@@ -36,7 +37,7 @@ describe('ShareDealRepositoryAdapter', () => {
         title: 'title',
         category: FoodCategory.AMERICAN,
         orderPrice: 2000,
-        ownerId: faker.database.mongodbObjectId(),
+        ownerId: UserId(faker.database.mongodbObjectId()),
         storeName: 'store',
         thumbnail: 'thumbnail',
         zone: shareZone,
@@ -58,7 +59,7 @@ describe('ShareDealRepositoryAdapter', () => {
         title: 'title',
         category: FoodCategory.AMERICAN,
         orderPrice: 2000,
-        ownerId: faker.database.mongodbObjectId(),
+        ownerId: UserId(faker.database.mongodbObjectId()),
         storeName: 'store',
         thumbnail: 'thumbnail',
         zone: new ShareZone(AddressSystem.ROAD, 'road', 'detail', 0, 0),
@@ -67,7 +68,7 @@ describe('ShareDealRepositoryAdapter', () => {
       const newShareDeal = await prisma.shareDeal
         .create({ data: ShareDealOrmMapper.toOrm(shareDeal) })
         .then(ShareDealOrmMapper.toDomain);
-      newShareDeal.join(faker.database.mongodbObjectId());
+      newShareDeal.join(UserId(faker.database.mongodbObjectId()));
 
       // when
       const result = shareDealRepositoryAdapter.save(newShareDeal);

--- a/apps/app/test/share-deal/unit/ParticipantInfo.spec.ts
+++ b/apps/app/test/share-deal/unit/ParticipantInfo.spec.ts
@@ -1,9 +1,10 @@
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
+import { UserId } from '../../../src/module/user/domain/User';
 
 describe('ParticipantInfo', () => {
   it('참여자 정보를 생성한다', () => {
     // given
-    const ids = ['1', '2', '3'];
+    const ids = ['1', '2', '3'].map(UserId);
     const max = 10;
 
     // when
@@ -18,10 +19,10 @@ describe('ParticipantInfo', () => {
 
   it('참여자를 추가한다', () => {
     // given
-    const info = ParticipantInfo.of(['1'], 3);
+    const info = ParticipantInfo.of([UserId('1')], 3);
 
     // when
-    const newInfo = info.addId('4');
+    const newInfo = info.addId(UserId('4'));
 
     // then
     expect(newInfo.ids).toEqual(['1', '4']);
@@ -33,7 +34,7 @@ describe('ParticipantInfo', () => {
   describe('canStart ', () => {
     it('참여자가 과반수 이상이면 true 이다', () => {
       // given
-      const info = ParticipantInfo.of(['1', '2', '3'], 5);
+      const info = ParticipantInfo.of(['1', '2', '3'].map(UserId), 5);
 
       // when
       const result = info.canStart;
@@ -44,7 +45,7 @@ describe('ParticipantInfo', () => {
 
     it('참여자가 과반수 보다 적으면 false 이다', () => {
       // given
-      const info = ParticipantInfo.of(['1', '2'], 5);
+      const info = ParticipantInfo.of(['1', '2'].map(UserId), 5);
 
       // when
       const result = info.canStart;

--- a/apps/app/test/share-deal/unit/ShareDeal.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDeal.spec.ts
@@ -1,5 +1,6 @@
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
 import { ShareDealStatus } from '../../../src/module/share-deal/domain/vo/ShareDealStatus';
+import { UserId } from '../../../src/module/user/domain/User';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 import { assertLeft, assertRight } from '../../fixture/utils';
 
@@ -7,10 +8,10 @@ describe('ShareDeal', () => {
   describe('canWriteChat', () => {
     it('공유딜이 시작 상태가 아니면 작성할 수 없다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.CLOSE,
-        participantInfo: ParticipantInfo.of([userId], 1),
+        participantInfo: ParticipantInfo.of([UserId(userId)], 1),
       });
 
       // when
@@ -22,10 +23,10 @@ describe('ShareDeal', () => {
 
     it('참가자가 아니면 작성할 수 없다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
-        participantInfo: ParticipantInfo.of(['other user'], 1),
+        participantInfo: ParticipantInfo.of([UserId('other user')], 1),
       });
 
       // when
@@ -37,10 +38,10 @@ describe('ShareDeal', () => {
 
     it('유효한 상태이면 작성할 수 있다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
-        participantInfo: ParticipantInfo.of([userId], 1),
+        participantInfo: ParticipantInfo.of([UserId(userId)], 1),
       });
 
       // when
@@ -54,11 +55,11 @@ describe('ShareDeal', () => {
   describe('canStart', () => {
     it('유효한 상태이면 시작할 수 있다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.OPEN,
         ownerId: userId,
-        participantInfo: ParticipantInfo.of([userId, 'user 2'], 4),
+        participantInfo: ParticipantInfo.of([userId, 'user 2'].map(UserId), 4),
       });
 
       // when
@@ -70,11 +71,11 @@ describe('ShareDeal', () => {
 
     it('방장이 아닌 경우 시작할 수 없다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.OPEN,
-        ownerId: 'user 2',
-        participantInfo: ParticipantInfo.of([userId, 'user 2'], 4),
+        ownerId: UserId('user 2'),
+        participantInfo: ParticipantInfo.of([userId, 'user 2'].map(UserId), 4),
       });
 
       // when
@@ -86,11 +87,11 @@ describe('ShareDeal', () => {
 
     it('상태가 OPEN이 아닌 경우 시작할 수 없다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
         ownerId: userId,
-        participantInfo: ParticipantInfo.of([userId, 'user 2'], 4),
+        participantInfo: ParticipantInfo.of([userId, 'user 2'].map(UserId), 4),
       });
 
       // when
@@ -102,11 +103,11 @@ describe('ShareDeal', () => {
 
     it('참여 인원이 과반수가 아닐 경우 시작할 수 없다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.OPEN,
         ownerId: userId,
-        participantInfo: ParticipantInfo.of([userId], 4),
+        participantInfo: ParticipantInfo.of([UserId(userId)], 4),
       });
 
       // when
@@ -120,11 +121,11 @@ describe('ShareDeal', () => {
   describe('canEnd', () => {
     it('유효한 상태이면 종료할 수 있다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
         ownerId: userId,
-        participantInfo: ParticipantInfo.of([userId, 'user 2'], 4),
+        participantInfo: ParticipantInfo.of([userId, 'user 2'].map(UserId), 4),
       });
 
       // when
@@ -136,11 +137,11 @@ describe('ShareDeal', () => {
 
     it('방장이 아닌 경우 종료할 수 없다', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
-        ownerId: 'user 2',
-        participantInfo: ParticipantInfo.of([userId, 'user 2'], 4),
+        ownerId: UserId('user 2'),
+        participantInfo: ParticipantInfo.of([userId, 'user 2'].map(UserId), 4),
       });
 
       // when
@@ -152,11 +153,11 @@ describe('ShareDeal', () => {
 
     it('상태가 START 아닌 경우 종료될 수 없다.', () => {
       // given
-      const userId = 'userId';
+      const userId = UserId('userId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.OPEN,
         ownerId: userId,
-        participantInfo: ParticipantInfo.of([userId, 'user 2'], 4),
+        participantInfo: ParticipantInfo.of([userId, 'user 2'].map(UserId), 4),
       });
 
       // when
@@ -170,13 +171,13 @@ describe('ShareDeal', () => {
   describe('canUpdate', () => {
     it('자신의 공유딜이 시작 상태인 경우 수정할 수 있다.', () => {
       // given
-      const ownerId = 'ownerId';
+      const ownerId = UserId('ownerId');
       const maxParticipants = 10;
       const shareDeal = ShareDealFactory.create({
         ownerId,
         status: ShareDealStatus.OPEN,
         participantInfo: ParticipantInfo.of(
-          ['user1', 'user2'],
+          ['user1', 'user2'].map(UserId),
           maxParticipants,
         ),
       });
@@ -192,13 +193,13 @@ describe('ShareDeal', () => {
       // given
       const maxParticipants = 10;
       const shareDeal = ShareDealFactory.createOpen({
-        ownerId: 'ownerId',
+        ownerId: UserId('ownerId'),
         participantInfo: ParticipantInfo.of(
-          ['user1', 'user2'],
+          ['user1', 'user2'].map(UserId),
           maxParticipants,
         ),
       });
-      const userId = 'userId';
+      const userId = UserId('userId');
 
       // when
       const result = shareDeal.canUpdate(userId, maxParticipants);
@@ -209,13 +210,13 @@ describe('ShareDeal', () => {
 
     it('오픈 상태가 아닌 경우 수정할 수 없다.', () => {
       // given
-      const ownerId = 'ownerId';
+      const ownerId = UserId('ownerId');
       const maxParticipants = 10;
       const shareDeal = ShareDealFactory.create({
         ownerId,
         status: ShareDealStatus.START,
         participantInfo: ParticipantInfo.of(
-          ['user1', 'user2'],
+          ['user1', 'user2'].map(UserId),
           maxParticipants,
         ),
       });
@@ -229,13 +230,13 @@ describe('ShareDeal', () => {
 
     it('현재 참여 인원수 보다 작은 인원수로 수정할 경우 실패한다.', () => {
       // given
-      const ownerId = 'ownerId';
+      const ownerId = UserId('ownerId');
       const maxParticipants = 1;
       const shareDeal = ShareDealFactory.create({
         ownerId,
         status: ShareDealStatus.START,
         participantInfo: ParticipantInfo.of(
-          ['user1', 'user2'],
+          ['user1', 'user2'].map(UserId),
           maxParticipants,
         ),
       });
@@ -251,10 +252,10 @@ describe('ShareDeal', () => {
   describe('leave', () => {
     it('공유딜이 활성화 상태이고 방장이면 파기상태로 변경한다', () => {
       // given
-      const ownerId = 'ownerId';
+      const ownerId = UserId('ownerId');
       const shareDeal = ShareDealFactory.createOpen({
         ownerId,
-        participantInfo: ParticipantInfo.of([ownerId, 'user2'], 10),
+        participantInfo: ParticipantInfo.of([ownerId, 'user2'].map(UserId), 10),
       });
 
       // when
@@ -270,12 +271,12 @@ describe('ShareDeal', () => {
     it('참여자가 아니면 에러를 반환한다', () => {
       // given
       const shareDeal = ShareDealFactory.createOpen({
-        ownerId: 'ownerId',
-        participantInfo: ParticipantInfo.of(['user1', 'user2'], 10),
+        ownerId: UserId('ownerId'),
+        participantInfo: ParticipantInfo.of(['user1', 'user2'].map(UserId), 10),
       });
 
       // when
-      const result = shareDeal.leave('user3');
+      const result = shareDeal.leave(UserId('user3'));
 
       // then
       assertLeft(result);
@@ -284,15 +285,15 @@ describe('ShareDeal', () => {
     it('참가자 정보를 삭제한다', () => {
       // given
       const shareDeal = ShareDealFactory.createOpen({
-        ownerId: 'ownerId',
-        participantInfo: ParticipantInfo.of(['user1', 'user2'], 10),
+        ownerId: UserId('ownerId'),
+        participantInfo: ParticipantInfo.of(['user1', 'user2'].map(UserId), 10),
       });
 
       // when
-      shareDeal.leave('user2');
+      shareDeal.leave(UserId('user2'));
 
       // then
-      expect(shareDeal.participantInfo.hasId('user2')).toBe(false);
+      expect(shareDeal.participantInfo.hasId(UserId('user2'))).toBe(false);
     });
   });
 });

--- a/apps/app/test/share-deal/unit/ShareDealCommandService.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDealCommandService.spec.ts
@@ -16,6 +16,7 @@ import { ShareDealCommandService } from '../../../src/module/share-deal/applicat
 import { FoodCategory } from '../../../src/module/share-deal/domain/vo/FoodCategory';
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
 import { ShareDealStatus } from '../../../src/module/share-deal/domain/vo/ShareDealStatus';
+import { UserId } from '../../../src/module/user/domain/User';
 import { AddressSystem } from '../../../src/module/user/domain/vo/AddressSystem';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 import { assertResolvesLeft, assertResolvesRight } from '../../fixture/utils';
@@ -39,7 +40,7 @@ describe('ShareDealCommandService', () => {
     it('공유딜 생성 요청을 수행한다.', async () => {
       // given
       const command = new OpenShareDealCommand(
-        'userId',
+        UserId('userId'),
         'title',
         FoodCategory.AMERICAN,
         10,
@@ -66,7 +67,7 @@ describe('ShareDealCommandService', () => {
   describe('join', () => {
     it('채팅 참여가 불가능한 공유딜에 참여 요청할 경우 NotOpenShareDealException이 반환된다.', async () => {
       // given
-      const command = new JoinShareDealCommand('userId', 'shareDealId');
+      const command = new JoinShareDealCommand(UserId('userId'), 'shareDealId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
       });
@@ -84,7 +85,7 @@ describe('ShareDealCommandService', () => {
 
     it('공유딜 채팅방 참여를 요청한다.', async () => {
       // given
-      const command = new JoinShareDealCommand('userId', 'shareDealId');
+      const command = new JoinShareDealCommand(UserId('userId'), 'shareDealId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.OPEN,
       });
@@ -105,11 +106,14 @@ describe('ShareDealCommandService', () => {
   describe('start', () => {
     it('방장은 공유딜을 시작할 수 있다', async () => {
       // given
-      const command = new StartShareDealCommand('userId', 'shareDealId');
+      const command = new StartShareDealCommand(
+        UserId('userId'),
+        'shareDealId',
+      );
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.OPEN,
         ownerId: command.userId,
-        participantInfo: ParticipantInfo.of(['1'], 2),
+        participantInfo: ParticipantInfo.of([UserId('1')], 2),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));
@@ -126,7 +130,10 @@ describe('ShareDealCommandService', () => {
 
     it('OPEN 상태가 아닌 경우 시작할 수 없다', async () => {
       // given
-      const command = new StartShareDealCommand('userId', 'shareDealId');
+      const command = new StartShareDealCommand(
+        UserId('userId'),
+        'shareDealId',
+      );
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.END,
       });
@@ -146,11 +153,11 @@ describe('ShareDealCommandService', () => {
   describe('end', () => {
     it('방장은 공유딜을 종료할 수 있다', async () => {
       // given
-      const command = new EndShareDealCommand('userId', 'shareDealId');
+      const command = new EndShareDealCommand(UserId('userId'), 'shareDealId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.START,
         ownerId: command.userId,
-        participantInfo: ParticipantInfo.of(['1'], 2),
+        participantInfo: ParticipantInfo.of([UserId('1')], 2),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));
@@ -167,7 +174,7 @@ describe('ShareDealCommandService', () => {
 
     it('START 상태가 아닌 경우 종료할 수 없다', async () => {
       // given
-      const command = new EndShareDealCommand('userId', 'shareDealId');
+      const command = new EndShareDealCommand(UserId('userId'), 'shareDealId');
       const shareDeal = ShareDealFactory.create({
         status: ShareDealStatus.END,
       });
@@ -187,7 +194,7 @@ describe('ShareDealCommandService', () => {
   describe('update', () => {
     it('공유딜 수정을 수행한다.', async () => {
       // given
-      const ownerId = 'ownerId';
+      const ownerId = UserId('ownerId');
       const shareDeal = ShareDealFactory.createOpen({
         ownerId,
       });
@@ -230,7 +237,10 @@ describe('ShareDealCommandService', () => {
   describe('leave', () => {
     it('참가자는 공유딜을 떠날 수 있다.', async () => {
       // given
-      const command = new LeaveShareDealCommand('userId', 'shareDealId');
+      const command = new LeaveShareDealCommand(
+        UserId('userId'),
+        'shareDealId',
+      );
       const shareDeal = ShareDealFactory.create({
         ownerId: command.userId,
         participantInfo: ParticipantInfo.of([command.userId], 2),
@@ -250,9 +260,9 @@ describe('ShareDealCommandService', () => {
 
     it('참가자가 아니면 에러를 반환한다', async () => {
       // given
-      const command = new EndShareDealCommand('userId', 'shareDealId');
+      const command = new EndShareDealCommand(UserId('userId'), 'shareDealId');
       const shareDeal = ShareDealFactory.create({
-        participantInfo: ParticipantInfo.of(['user1'], 2),
+        participantInfo: ParticipantInfo.of([UserId('user1')], 2),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));

--- a/apps/app/test/share-deal/unit/ShareDealQueryResolver.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDealQueryResolver.spec.ts
@@ -13,6 +13,7 @@ import { FoodCategory } from '../../../src/module/share-deal/domain/vo/FoodCateg
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
 import { ShareZone } from '../../../src/module/share-deal/domain/vo/ShareZone';
 import { UserQueryRepositoryPort } from '../../../src/module/user/application/port/out/UserQueryRepositoryPort';
+import { UserId } from '../../../src/module/user/domain/User';
 import { Address } from '../../../src/module/user/domain/vo/Address';
 import { AddressSystem } from '../../../src/module/user/domain/vo/AddressSystem';
 import { AddressType } from '../../../src/module/user/domain/vo/AddressType';
@@ -91,7 +92,7 @@ describe('ShareDealQueryResolver', () => {
         title: 'title',
         createdAt: new Date('2022-01-01'),
         thumbnail: 'thumbnail',
-        participantInfo: ParticipantInfo.of(['1', '2', '3'], 10),
+        participantInfo: ParticipantInfo.of(['1', '2', '3'].map(UserId), 10),
         category: FoodCategory.CHINESE,
         zone: new ShareZone(AddressSystem.ROAD, 'road', 'detail', 123.5, 45.6),
       });
@@ -184,7 +185,7 @@ describe('ShareDealQueryResolver', () => {
         title: 'title',
         createdAt: new Date('2022-01-01'),
         thumbnail: 'thumbnail',
-        participantInfo: ParticipantInfo.of(['1', '2', '3'], 10),
+        participantInfo: ParticipantInfo.of(['1', '2', '3'].map(UserId), 10),
         category: FoodCategory.CHINESE,
         zone: new ShareZone(AddressSystem.JIBUN, 'road', 'detail', 123.5, 45.6),
       });

--- a/apps/app/test/share-deal/unit/ShareDealQueryService.spec.ts
+++ b/apps/app/test/share-deal/unit/ShareDealQueryService.spec.ts
@@ -6,6 +6,7 @@ import { ShareDealQueryRepositoryPort } from '../../../src/module/share-deal/app
 import { ShareDealQueryService } from '../../../src/module/share-deal/application/service/ShareDealQueryService';
 import { ParticipantInfo } from '../../../src/module/share-deal/domain/vo/ParticipantInfo';
 import { ShareDealStatus } from '../../../src/module/share-deal/domain/vo/ShareDealStatus';
+import { UserId } from '../../../src/module/user/domain/User';
 import { ShareDealFactory } from '../../fixture/ShareDealFactory';
 import { assertResolvesLeft, assertResolvesRight } from '../../fixture/utils';
 
@@ -27,7 +28,7 @@ describe('ShareDealQueryService', () => {
       // when
       const result = shareDealQueryService.isParticipant(
         shareDeal.id,
-        'not match user',
+        UserId('not match user'),
       );
 
       // then
@@ -40,7 +41,10 @@ describe('ShareDealQueryService', () => {
       // given
       const shareDeal = ShareDealFactory.create({
         id: 'shareDealId',
-        participantInfo: ParticipantInfo.of(['user 1', 'user 2'], 5),
+        participantInfo: ParticipantInfo.of(
+          ['user 1', 'user 2'].map(UserId),
+          5,
+        ),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));
@@ -62,7 +66,7 @@ describe('ShareDealQueryService', () => {
       const shareDeal = ShareDealFactory.create({
         id: 'shareDealId',
         status: ShareDealStatus.END,
-        participantInfo: ParticipantInfo.of(['user'], 2),
+        participantInfo: ParticipantInfo.of([UserId('user')], 2),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));
@@ -84,7 +88,10 @@ describe('ShareDealQueryService', () => {
       const shareDeal = ShareDealFactory.create({
         id: 'shareDealId',
         status: ShareDealStatus.START,
-        participantInfo: ParticipantInfo.of(['user 1', 'user 2'], 5),
+        participantInfo: ParticipantInfo.of(
+          ['user 1', 'user 2'].map(UserId),
+          5,
+        ),
       });
 
       shareDealQueryRepositoryPort.findById.mockReturnValue(right(shareDeal));

--- a/apps/app/test/user-push-token/integration/UserPushTokenRepositoryAdapter.spec.ts
+++ b/apps/app/test/user-push-token/integration/UserPushTokenRepositoryAdapter.spec.ts
@@ -1,6 +1,7 @@
 import { PrismaService } from '@app/prisma/PrismaService';
 import { faker } from '@faker-js/faker';
 
+import { UserId } from '../../../src/module/user/domain/User';
 import { UserPushTokenRepositoryAdapter } from '../../../src/module/user-push-token/adapter/out/persistence/UserPushTokenRepositoryAdapter';
 import { UserPushToken } from '../../../src/module/user-push-token/domain/UserPushToken';
 import { assertResolvesRight } from '../../fixture/utils';
@@ -19,7 +20,7 @@ describe('UserPushTokenRepositoryAdapter', () => {
     it('주어진 푸시토큰 데이터를 생성한다', async () => {
       // given
       const userToken = new UserPushToken({
-        userId: faker.database.mongodbObjectId(),
+        userId: UserId(faker.database.mongodbObjectId()),
         token: 'token',
       });
 

--- a/apps/app/test/user-push-token/unit/UserPushTokenEventListener.spec.ts
+++ b/apps/app/test/user-push-token/unit/UserPushTokenEventListener.spec.ts
@@ -5,6 +5,7 @@ import { StubPushMessage } from '../../../../../libs/push-message/test/fixture/S
 import { Chat } from '../../../src/module/chat/domain/Chat';
 import { ChatWrittenEvent } from '../../../src/module/chat/domain/event/ChatWrittenEvent';
 import { Message } from '../../../src/module/chat/domain/vo/Message';
+import { UserId } from '../../../src/module/user/domain/User';
 import { UserPushTokenEventListener } from '../../../src/module/user-push-token/adapter/in/listener/UserPushTokenEventListener';
 import { UserPushTokenQueryRepositoryPort } from '../../../src/module/user-push-token/application/port/out/UserPushTokenQueryRepositoryPort';
 import { UserPushToken } from '../../../src/module/user-push-token/domain/UserPushToken';
@@ -29,9 +30,9 @@ describe('UserPushTokenEventListener', () => {
       const chats = new ChatWrittenEvent([
         Chat.of({
           shareDealId: 'shareDealId',
-          userId: 'authorId',
+          userId: UserId('authorId'),
           orderedKey: 'orderedKey',
-          message: Message.normal('authorId', 'content', false),
+          message: Message.normal(UserId('authorId'), 'content', false),
         }),
       ]);
 
@@ -48,14 +49,16 @@ describe('UserPushTokenEventListener', () => {
       const chats = new ChatWrittenEvent([
         Chat.of({
           shareDealId: 'shareDealId',
-          userId: 'userId',
+          userId: UserId('userId'),
           orderedKey: 'orderedKey',
-          message: Message.normal('authorId', 'content', false),
+          message: Message.normal(UserId('authorId'), 'content', false),
         }),
       ]);
 
       userPushTokenQueryRepositoryPort.findByUserIds.mockReturnValue(
-        right([new UserPushToken({ userId: 'userId', token: 'token' })]),
+        right([
+          new UserPushToken({ userId: UserId('userId'), token: 'token' }),
+        ]),
       );
 
       // when

--- a/apps/app/test/user/integration/PhoneVerificationRepositoryAdapter.spec.ts
+++ b/apps/app/test/user/integration/PhoneVerificationRepositoryAdapter.spec.ts
@@ -4,6 +4,7 @@ import { faker } from '@faker-js/faker';
 
 import { PhoneVerificationRepositoryAdapter } from '../../../src/module/user/adapter/out/persistence/PhoneVerificationRepositoryAdapter';
 import { PhoneVerification } from '../../../src/module/user/domain/PhoneVerification';
+import { UserId } from '../../../src/module/user/domain/User';
 import { assertResolvesLeft, assertResolvesRight } from '../../fixture/utils';
 
 describe('PhoneVerificationRepositoryAdapter', () => {
@@ -22,7 +23,7 @@ describe('PhoneVerificationRepositoryAdapter', () => {
 
       // when
       const result = phoneVerificationRepositoryAdapter.save(
-        faker.database.mongodbObjectId(),
+        UserId(faker.database.mongodbObjectId()),
         phoneVerification,
       );
 
@@ -36,7 +37,7 @@ describe('PhoneVerificationRepositoryAdapter', () => {
   describe('findLatest', () => {
     it('주어진 사용자에 대한 인증번호가 없으면 에러가 발생한다', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
 
       // when
       const result = phoneVerificationRepositoryAdapter.findLatest(userId);
@@ -53,7 +54,7 @@ describe('PhoneVerificationRepositoryAdapter', () => {
 
     it('주어진 사용자에 대한 가장 최근 인증번호를 가져온다', async () => {
       // given
-      const userId = faker.database.mongodbObjectId();
+      const userId = UserId(faker.database.mongodbObjectId());
       await prisma.phoneVerification.create({
         data: {
           phoneNumber: '01011112222',

--- a/apps/app/test/user/unit/PhoneVerificationService.spec.ts
+++ b/apps/app/test/user/unit/PhoneVerificationService.spec.ts
@@ -11,7 +11,7 @@ import { UserRepositoryPort } from '../../../src/module/user/application/port/ou
 import { PhoneVerificationService } from '../../../src/module/user/application/service/PhoneVerificationService';
 import { MismatchedCodeException } from '../../../src/module/user/domain/exception/MismatchedCodeException';
 import { PhoneVerification } from '../../../src/module/user/domain/PhoneVerification';
-import { User } from '../../../src/module/user/domain/User';
+import { User, UserId } from '../../../src/module/user/domain/User';
 import { Auth } from '../../../src/module/user/domain/vo/Auth';
 import { AuthType } from '../../../src/module/user/domain/vo/AuthType';
 import { assertResolvesLeft, assertResolvesRight } from '../../fixture/utils';
@@ -36,7 +36,10 @@ describe('PhoneVerificationService', () => {
   describe('sendCode', () => {
     it('전화번호 인증코드를 전송한다', async () => {
       // given
-      const command = new SendPhoneVerificationCodeCommand('id', '01011112222');
+      const command = new SendPhoneVerificationCodeCommand(
+        UserId('id'),
+        '01011112222',
+      );
 
       phoneVerificationRepository.save.mockReturnValue(
         right(PhoneVerification.of(command.phoneNumber)),
@@ -54,7 +57,10 @@ describe('PhoneVerificationService', () => {
   describe('verify', () => {
     it('인증번호가 없으면 에러를 반환한다', async () => {
       // given
-      const command = new VerifyPhoneVerificationCodeCommand('id', '1234');
+      const command = new VerifyPhoneVerificationCodeCommand(
+        UserId('id'),
+        '1234',
+      );
 
       const notFoundException = new NotFoundException('');
       phoneVerificationRepository.findLatest.mockReturnValue(
@@ -73,7 +79,10 @@ describe('PhoneVerificationService', () => {
     it('인증번호 검증에 실패하면 에러를 반환한다', async () => {
       // given
       const phoneVerification = PhoneVerification.of('01011112222', '1234');
-      const command = new VerifyPhoneVerificationCodeCommand('id', '1245');
+      const command = new VerifyPhoneVerificationCodeCommand(
+        UserId('id'),
+        '1245',
+      );
       const user = User.byAuth(new Auth('id', AuthType.GOOGLE));
 
       userQueryRepository.findById.mockReturnValue(right(user));
@@ -94,7 +103,7 @@ describe('PhoneVerificationService', () => {
       // given
       const phoneVerification = PhoneVerification.of('01011112222', '1234');
       const command = new VerifyPhoneVerificationCodeCommand(
-        'id',
+        UserId('id'),
         phoneVerification.code,
       );
       const user = User.byAuth(new Auth('id', AuthType.GOOGLE));

--- a/apps/app/test/user/unit/UserCommandService.spec.ts
+++ b/apps/app/test/user/unit/UserCommandService.spec.ts
@@ -16,7 +16,7 @@ import { TokenGeneratorPort } from '../../../src/module/user/application/port/ou
 import { UserQueryRepositoryPort } from '../../../src/module/user/application/port/out/UserQueryRepositoryPort';
 import { UserRepositoryPort } from '../../../src/module/user/application/port/out/UserRepositoryPort';
 import { UserCommandService } from '../../../src/module/user/application/service/UserCommandService';
-import { User } from '../../../src/module/user/domain/User';
+import { User, UserId } from '../../../src/module/user/domain/User';
 import { Address } from '../../../src/module/user/domain/vo/Address';
 import { AddressSystem } from '../../../src/module/user/domain/vo/AddressSystem';
 import { AddressType } from '../../../src/module/user/domain/vo/AddressType';
@@ -98,7 +98,7 @@ describe('UserCommandService', () => {
     it('사용자 등록에 성공한다', async () => {
       // given
       const command = new EnrollUserCommand(
-        'userId',
+        UserId('userId'),
         'nickname',
         10.2,
         20.3,
@@ -125,7 +125,7 @@ describe('UserCommandService', () => {
     it('유저가 없으면 NotFoundException 을 반환한다', async () => {
       // given
       const command = new EnrollUserCommand(
-        'userId',
+        UserId('userId'),
         'nickname',
         10.2,
         20.3,
@@ -150,7 +150,11 @@ describe('UserCommandService', () => {
     it('회원탈퇴 처리한다', async () => {
       // given
       const now = new Date();
-      const command = new LeaveUserCommand('userId', 'nickname', 'reason');
+      const command = new LeaveUserCommand(
+        UserId('userId'),
+        'nickname',
+        'reason',
+      );
 
       const auth = new Auth('socialId', AuthType.GOOGLE);
       const user = User.byAuth(auth);
@@ -173,7 +177,7 @@ describe('UserCommandService', () => {
     it('주소가 6개 이상이면 에러가 발생한다', async () => {
       // given
       const command = new AppendAddressCommand(
-        'userId',
+        UserId('userId'),
         10,
         20,
         AddressType.HOME,
@@ -214,7 +218,7 @@ describe('UserCommandService', () => {
     it('주소등록에 성공한다', async () => {
       // given
       const command = new AppendAddressCommand(
-        'userId',
+        UserId('userId'),
         10,
         20,
         AddressType.HOME,
@@ -240,7 +244,7 @@ describe('UserCommandService', () => {
   describe('deleteAddress', () => {
     it('주어진 주소를 삭제한다', async () => {
       // given
-      const command = new DeleteAddressCommand('1', 'userId');
+      const command = new DeleteAddressCommand('1', UserId('userId'));
 
       const user = UserFactory.create({
         addressList: UserAddressList.of([
@@ -290,7 +294,7 @@ describe('UserCommandService', () => {
   describe('updateProfile', () => {
     it('프로필 정보를 수정한다.', async () => {
       // given
-      const command = new UpdateProfileCommand('userId', 'introduce');
+      const command = new UpdateProfileCommand(UserId('userId'), 'introduce');
       const user = UserFactory.create();
 
       userQueryRepository.findById.mockReturnValue(right(user));

--- a/libs/domain/src/entity/BaseBrandedEntity.ts
+++ b/libs/domain/src/entity/BaseBrandedEntity.ts
@@ -1,0 +1,39 @@
+export interface BaseEntityProps<PK> {
+  id: PK;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export abstract class BaseBrandedEntity<PROPS, PK>
+  implements BaseEntityProps<PK>
+{
+  protected props: PROPS;
+
+  private readonly _id: PK;
+  private readonly _createdAt: Date;
+  private _updatedAt: Date;
+
+  protected constructor(props: PROPS) {
+    this.props = props;
+  }
+
+  get id(): PK {
+    return this._id;
+  }
+
+  get createdAt(): Date {
+    return this._createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this._updatedAt;
+  }
+
+  setBase(id: string, createdAt: Date, updatedAt: Date) {
+    (this._id as any) = id.toString();
+    (this._createdAt as any) = createdAt;
+    this._updatedAt = updatedAt;
+
+    return this;
+  }
+}

--- a/libs/domain/src/entity/Branded.ts
+++ b/libs/domain/src/entity/Branded.ts
@@ -1,0 +1,1 @@
+export type Branded<T, B extends string> = T & { __brand: B };


### PR DESCRIPTION
resolves #153

엔티티의 id를 단순히 string으로 선언하는 경우 일반 문자열로 사용되는 변수와 구별하기 어렵고 함수의 파라미터 순서를 잘못 넣어서 주는 실수를 막기위한 branded 타입 도입